### PR TITLE
crofbase: api change for get_dpt

### DIFF
--- a/src/rofl/common/crofbase.cc
+++ b/src/rofl/common/crofbase.cc
@@ -488,7 +488,7 @@ crofbase::handle_established(
 		if (conn.get_auxid() == rofl::cauxid(0)) {
 			journal.log(LOG_INFO, "datapath attached").
 						set_key("dptid", dptid.str()).
-						set_key("version", get_dpt(dptid).get_version());
+						set_key("version", get_const_dpt(dptid).get_version());
 			handle_dpt_open(set_dpt(dptid));
 		}
 		journal.log(LOG_INFO, "connection established").

--- a/src/rofl/common/crofbase.h
+++ b/src/rofl/common/crofbase.h
@@ -528,6 +528,16 @@ public:
 	 * @throws eRofBaseNotFound
 	 */
 	const rofl::crofdpt&
+	get_const_dpt(
+			const rofl::cdptid& dptid) const {
+		AcquireReadLock rlock(rofdpts_rwlock);
+		if (rofdpts.find(dptid) == rofdpts.end()) {
+			throw eRofBaseNotFound("rofl::crofbase::get__const_dpt() dptid not found");
+		}
+		return *(rofdpts.at(dptid));
+	};
+
+	rofl::crofdpt&
 	get_dpt(
 			const rofl::cdptid& dptid) const {
 		AcquireReadLock rlock(rofdpts_rwlock);
@@ -535,7 +545,7 @@ public:
 			throw eRofBaseNotFound("rofl::crofbase::get_dpt() dptid not found");
 		}
 		return *(rofdpts.at(dptid));
-	};
+	}
 
 	/**
 	 * @brief	Deletes a rofl::crofdpt instance given by identifier.


### PR DESCRIPTION
Using get_dpt we are not able to send OF messages. The only solution
is to consecutively call has_dpt and set_dpt, which is quite
inefficient. Therefore there are now get_dpt and get_const_dpt.