### PR TITLE
fixes in ctimespec

### DIFF
--- a/src/rofl/common/ctimespec.cpp
+++ b/src/rofl/common/ctimespec.cpp
@@ -39,19 +39,16 @@ ctimespec
 ctimespec::operator- (
 		const ctimespec& t) const
 {
-	ctimespec timer;
+	ctimespec timer(::timespec {0,0});
 
-	if (t.tspec.tv_nsec > tspec.tv_nsec) {
-		if (tspec.tv_sec > t.tspec.tv_sec) {
+	if (tspec.tv_sec > t.tspec.tv_sec) {
+		if (t.tspec.tv_nsec > tspec.tv_nsec) {
 			timer.tspec.tv_nsec = tspec.tv_nsec - t.tspec.tv_nsec + CC_TIMER_ONE_SECOND_NS;
-			timer.tspec.tv_sec	= tspec.tv_sec  - t.tspec.tv_sec  - CC_TIMER_ONE_SECOND_S;
+			timer.tspec.tv_sec  = tspec.tv_sec  - t.tspec.tv_sec  - CC_TIMER_ONE_SECOND_S;
 		} else {
-			timer.tspec.tv_nsec = 0;
-			timer.tspec.tv_sec	= 0;
+			timer.tspec.tv_nsec = tspec.tv_nsec - t.tspec.tv_nsec;
+			timer.tspec.tv_sec  = tspec.tv_sec  - t.tspec.tv_sec;
 		}
-	} else {
-		timer.tspec.tv_nsec	= tspec.tv_nsec - t.tspec.tv_nsec;
-		timer.tspec.tv_sec	= tspec.tv_sec  - t.tspec.tv_sec;
 	}
 
 	return timer;
@@ -80,17 +77,14 @@ ctimespec&
 ctimespec::operator-= (
 		const ctimespec& t)
 {
-	if (t.tspec.tv_nsec > tspec.tv_nsec) {
-		if (tspec.tv_sec > t.tspec.tv_sec) {
-			tspec.tv_nsec 	= tspec.tv_nsec - t.tspec.tv_nsec + CC_TIMER_ONE_SECOND_NS;
-			tspec.tv_sec	= tspec.tv_sec  - t.tspec.tv_sec  - CC_TIMER_ONE_SECOND_S;
+	if (tspec.tv_sec > t.tspec.tv_sec) {
+		if (t.tspec.tv_nsec > tspec.tv_nsec) {
+			tspec.tv_nsec = tspec.tv_nsec - t.tspec.tv_nsec + CC_TIMER_ONE_SECOND_NS;
+			tspec.tv_sec  = tspec.tv_sec  - t.tspec.tv_sec  - CC_TIMER_ONE_SECOND_S;
 		} else {
-			tspec.tv_nsec 	= 0;
-			tspec.tv_sec	= 0;
+			tspec.tv_nsec = tspec.tv_nsec - t.tspec.tv_nsec;
+			tspec.tv_sec  = tspec.tv_sec  - t.tspec.tv_sec;
 		}
-	} else {
-		tspec.tv_nsec	= tspec.tv_nsec - t.tspec.tv_nsec;
-		tspec.tv_sec	= tspec.tv_sec  - t.tspec.tv_sec;
 	}
 
 	return *this;

--- a/src/rofl/common/ctimespec.hpp
+++ b/src/rofl/common/ctimespec.hpp
@@ -148,6 +148,15 @@ public:
 	 *
 	 */
 	ctimespec(
+			struct timespec tspec,
+			const cclockid& clk_id = cclockid(CLOCK_MONOTONIC)) :
+			        timer_id(0),
+			        clk_id(clk_id)
+	{ this->tspec.tv_nsec = tspec.tv_nsec; this->tspec.tv_sec = tspec.tv_sec; };
+	/**
+	 *
+	*/
+	ctimespec(
 			const ctimespec& ts)
 	{ *this = ts; };
 


### PR DESCRIPTION
* fixed a crucial bug in operators `-` and `-=` in class ctimespec
* added new constructor for ctimespec to help with the fix
* performance improvement due to new constructor not calling system clock