### PR TITLE
timer: don't drop timers

### DIFF
--- a/src/rofl/common/ctimespec.cpp
+++ b/src/rofl/common/ctimespec.cpp
@@ -122,6 +122,9 @@ ctimespec::operator< (
 	}
 
 	// here: tspec.tv_nsec == t.tspec.tv_nsec
+	if (timer_id < t.timer_id) {
+		return true;
+	}
 
 	return false;
 }
@@ -158,6 +161,10 @@ ctimespec::operator> (
 
 	// here: tspec.tv_nsec == t.tspec.tv_nsec
 
+	if (timer_id > t.timer_id) {
+		return true;
+	}
+
 	return false;
 }
 
@@ -175,6 +182,6 @@ bool
 ctimespec::operator== (
 		const ctimespec& t) const
 {
-	return ((not (*this < t)) && (not (t < *this)));
+	return (tspec.tv_sec == t.tspec.tv_sec && tspec.tv_nsec == t.tspec.tv_nsec);
 }
 


### PR DESCRIPTION
in case timers are having the same timespec, the latter timer is
dropped in the set ordered_timers. This resolves the issue and checks
as well the timer_id.