### PR TITLE
ctimespec: prevent data race

### DIFF
--- a/src/rofl/common/ctimer.hpp
+++ b/src/rofl/common/ctimer.hpp
@@ -48,7 +48,7 @@ public:
 	 *
 	 */
 	static
-	const ctimespec&
+	const ctimespec
 	now(
 			cclockid clk_id = cclockid(CLOCK_MONOTONIC)) {
 		return ctimespec::now(clk_id);

--- a/src/rofl/common/ctimespec.cpp
+++ b/src/rofl/common/ctimespec.cpp
@@ -13,9 +13,6 @@
 
 using namespace rofl;
 
-/*static*/ctimespec ctimespec::current_time;
-
-
 ctimespec
 ctimespec::operator+ (
 		const ctimespec& t) const

--- a/src/rofl/common/ctimespec.hpp
+++ b/src/rofl/common/ctimespec.hpp
@@ -109,11 +109,10 @@ public:
 	 *
 	 */
 	static
-	const ctimespec&
+	const ctimespec
 	now(
 			const cclockid& clk_id = cclockid(CLOCK_MONOTONIC)) {
-		ctimespec::current_time.get_time(clk_id);
-		return ctimespec::current_time;
+		return ctimespec(clk_id);
 	};
 
 public:
@@ -412,7 +411,6 @@ public:
 
 private:
 
-	static ctimespec        current_time;
 	static const long       CC_TIMER_ONE_SECOND_S = 1;
 	static const long       CC_TIMER_ONE_SECOND_NS = 1000000000;
 


### PR DESCRIPTION
calls to rofl::ctimespec::now() can occur from differnt thread
contexts. This leads to an update of the timespec, that is returned as
reference.

Sanitizer log:
```
WARNING: ThreadSanitizer: data race (pid=3116)
  Write of size 8 at 0x00000090c028 by thread T1 (mutexes: write M137):
    #0 clock_gettime <null> (libtsan.so.0+0x0000000332eb)
    #1 rofl::ctimespec::get_time(rofl::cclockid const&) /home/tobi/workspace/rofl-common/src/rofl/common/ctimespec.hpp:313 (crofsocktest+0x00000044b7cf)
    #2 rofl::ctimespec::now(rofl::cclockid const&) /home/tobi/workspace/rofl-common/src/rofl/common/ctimespec.hpp:115 (crofsocktest+0x000000454ea1)
    #3 rofl::cjrnentry::cjrnentry(unsigned int) /home/tobi/workspace/rofl-common/src/rofl/common/cjrnentry.hpp:53 (crofsocktest+0x000000454ea1)
    #4 rofl::cjournal::add_log_entry() /home/tobi/workspace/rofl-common/src/rofl/common/cjournal.hpp:272 (crofsocktest+0x000000454ea1)
    #5 rofl::cjournal::log(rofl::cjournal_level_t, char const*, ...) /home/tobi/workspace/rofl-common/src/rofl/common/cjournal.hpp:208 (crofsocktest+0x0000004554b5)
    #6 rofl::crofsock::handle_read_event_rxthread(rofl::cthread&, int) /home/tobi/workspace/rofl-common/src/rofl/common/crofsock.cc:1624 (crofsocktest+0x000000449a40)
    #7 rofl::crofsock::handle_read_event(rofl::cthread&, int) /home/tobi/workspace/rofl-common/src/rofl/common/crofsock.cc:1610 (crofsocktest+0x00000044ab8a)
    #8 rofl::cthread::run_loop() /home/tobi/workspace/rofl-common/src/rofl/common/cthread.cpp:579 (crofsocktest+0x000000469dd0)
    #9 rofl::cthread::start_loop(void*) /home/tobi/workspace/rofl-common/src/rofl/common/cthread.hpp:322 (crofsocktest+0x00000046cc7c)
    #10 <null> <null> (libtsan.so.0+0x000000024549)

  Previous write of size 8 at 0x00000090c028 by main thread (mutexes: write M149):
    #0 clock_gettime <null> (libtsan.so.0+0x0000000332eb)
    #1 rofl::ctimespec::get_time(rofl::cclockid const&) /home/tobi/workspace/rofl-common/src/rofl/common/ctimespec.hpp:313 (crofsocktest+0x00000044b7cf)
    #2 rofl::ctimespec::now(rofl::cclockid const&) /home/tobi/workspace/rofl-common/src/rofl/common/ctimespec.hpp:115 (crofsocktest+0x000000454ea1)
    #3 rofl::cjrnentry::cjrnentry(unsigned int) /home/tobi/workspace/rofl-common/src/rofl/common/cjrnentry.hpp:53 (crofsocktest+0x000000454ea1)
    #4 rofl::cjournal::add_log_entry() /home/tobi/workspace/rofl-common/src/rofl/common/cjournal.hpp:272 (crofsocktest+0x000000454ea1)
    #5 rofl::cjournal::log(rofl::cjournal_level_t, char const*, ...) /home/tobi/workspace/rofl-common/src/rofl/common/cjournal.hpp:208 (crofsocktest+0x0000004554b5)
    #6 rofl::crofsock::tcp_connect(bool) /home/tobi/workspace/rofl-common/src/rofl/common/crofsock.cc:572 (crofsocktest+0x00000043db6a)
    #7 crofsocktest::test() /home/tobi/workspace/rofl-common/test/rofl/common/crofsock/crofsocktest.cpp:65 (crofsocktest+0x0000004120c4)
    #8 CppUnit::TestCaller<crofsocktest>::runTest() /usr/include/cppunit/TestCaller.h:166 (crofsocktest+0x00000041596e)
    #9 CppUnit::TestCaseMethodFunctor::operator()() const <null> (libcppunit-1.13.so.0+0x000000022c81)
    #10 __libc_start_main <null> (libc.so.6+0x000000020400)

  Location is global 'rofl::ctimespec::current_time' of size 88 at 0x00000090bfe0 (crofsocktest+0x00000090c028)

  Mutex M137 (0x7d680001f2f8) created at:
    #0 pthread_rwlock_init <null> (libtsan.so.0+0x00000002956b)
    #1 rofl::crwlock::crwlock() /home/tobi/workspace/rofl-common/src/rofl/common/locking.hpp:33 (crofsocktest+0x0000004529a9)
    #2 rofl::cjournal::cjournal(rofl::cjournal_env*) /home/tobi/workspace/rofl-common/src/rofl/common/cjournal.hpp:117 (crofsocktest+0x000000438a88)
    #3 rofl::crofsock::crofsock(rofl::crofsock_env*) /home/tobi/workspace/rofl-common/src/rofl/common/crofsock.cc:75 (crofsocktest+0x000000438a88)
    #4 crofsocktest::test() /home/tobi/workspace/rofl-common/test/rofl/common/crofsock/crofsocktest.cpp:44 (crofsocktest+0x000000411259)
    #5 CppUnit::TestCaller<crofsocktest>::runTest() /usr/include/cppunit/TestCaller.h:166 (crofsocktest+0x00000041596e)
    #6 CppUnit::TestCaseMethodFunctor::operator()() const <null> (libcppunit-1.13.so.0+0x000000022c81)
    #7 __libc_start_main <null> (libc.so.6+0x000000020400)

  Mutex M149 (0x7d680001ecf8) created at:
    #0 pthread_rwlock_init <null> (libtsan.so.0+0x00000002956b)
    #1 rofl::crwlock::crwlock() /home/tobi/workspace/rofl-common/src/rofl/common/locking.hpp:33 (crofsocktest+0x0000004529a9)
    #2 rofl::cjournal::cjournal(rofl::cjournal_env*) /home/tobi/workspace/rofl-common/src/rofl/common/cjournal.hpp:117 (crofsocktest+0x000000438a88)
    #3 rofl::crofsock::crofsock(rofl::crofsock_env*) /home/tobi/workspace/rofl-common/src/rofl/common/crofsock.cc:75 (crofsocktest+0x000000438a88)
    #4 crofsocktest::test() /home/tobi/workspace/rofl-common/test/rofl/common/crofsock/crofsocktest.cpp:45 (crofsocktest+0x000000411288)
    #5 CppUnit::TestCaller<crofsocktest>::runTest() /usr/include/cppunit/TestCaller.h:166 (crofsocktest+0x00000041596e)
    #6 CppUnit::TestCaseMethodFunctor::operator()() const <null> (libcppunit-1.13.so.0+0x000000022c81)
    #7 __libc_start_main <null> (libc.so.6+0x000000020400)

  Thread T1 (tid=3118, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.0+0x000000028490)
    #1 rofl::cthread::start() /home/tobi/workspace/rofl-common/src/rofl/common/cthread.cpp:414 (crofsocktest+0x000000463ecd)
    #2 rofl::crofsock::crofsock(rofl::crofsock_env*) /home/tobi/workspace/rofl-common/src/rofl/common/crofsock.cc:83 (crofsocktest+0x000000439619)
    #3 crofsocktest::test() /home/tobi/workspace/rofl-common/test/rofl/common/crofsock/crofsocktest.cpp:44 (crofsocktest+0x000000411259)
    #4 CppUnit::TestCaller<crofsocktest>::runTest() /usr/include/cppunit/TestCaller.h:166 (crofsocktest+0x00000041596e)
    #5 CppUnit::TestCaseMethodFunctor::operator()() const <null> (libcppunit-1.13.so.0+0x000000022c81)
    #6 __libc_start_main <null> (libc.so.6+0x000000020400)

SUMMARY: ThreadSanitizer: data race (/lib64/libtsan.so.0+0x332eb) in __interceptor_clock_gettime
```