### PR TITLE
cthread: cleanup locking and api

### DIFF
--- a/examples/ethswctld/cfibentry.h
+++ b/examples/ethswctld/cfibentry.h
@@ -159,7 +159,10 @@ private:
    *
    * @see rofl::ciosrv
    */
-  virtual void handle_timeout(cthread &thread, uint32_t timer_id);
+  void handle_timeout(cthread &thread, uint32_t timer_id) override;
+  void handle_read_event(cthread &thread, int fd) override {}
+  void handle_write_event(cthread &thread, int fd) override {}
+  void handle_wakeup(cthread &thread) override {}
 
 public:
   /**

--- a/examples/ethswctld/cflowentry.h
+++ b/examples/ethswctld/cflowentry.h
@@ -170,7 +170,10 @@ private:
   void flow_mod_modify();
 
 private:
-  virtual void handle_timeout(cthread &thread, uint32_t timer_id);
+  void handle_timeout(cthread &thread, uint32_t timer_id) override;
+  void handle_read_event(cthread &thread, int fd) override {}
+  void handle_write_event(cthread &thread, int fd) override {}
+  void handle_wakeup(cthread &thread) override {}
 
 public:
   /**


### PR DESCRIPTION
Removed thread environment locking, since env is thread local. Thread
environment is now a pure virtual interface. Thread running variable
was stored in global locked map, that is now replaced by a local atomic
running flag.