### PR TITLE
for your consideration

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,11 @@ Legend:
 [O] Other
 [A] API semantics
 
+On This Branch
+==============
+[B] crofsock: send_from_queue gets into CPU spin if last send in queue fragments.
+[B] cofaction: (~ line 1980) zero buffer on set_field as OpenVSwitch checks for zero padding.
+
 Change log
 ==========
 

--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,7 @@ Legend:
 
 On This Branch
 ==============
+[B] crofsock: send_from_queue gets into CPU spin due to out-of-synchronization pending packet count
 [B] crofsock: send_from_queue gets into CPU spin if last send in queue fragments.
 [B] cofaction: (~ line 1980) zero buffer on set_field as OpenVSwitch checks for zero padding.
 

--- a/src/rofl/common/crofsock.h
+++ b/src/rofl/common/crofsock.h
@@ -34,6 +34,7 @@
 #include <bitset>
 #include <iostream>
 #include <algorithm>
+#include <mutex>
 
 #include <openssl/bio.h>
 #include <openssl/ssl.h>
@@ -989,6 +990,7 @@ private:
 
     // number of packets waiting for transmission
     unsigned int                txqueue_pending_pkts;
+	std::mutex                  txqueue_pending_pkts_mutex;
 
     // size of tx queue when congestion occured
     unsigned int                txqueue_size_congestion_occured;

--- a/src/rofl/common/crofsock.h
+++ b/src/rofl/common/crofsock.h
@@ -855,6 +855,8 @@ private:
 	send_from_queue();
 
 private:
+	bool
+	send_from_buffer();
 
 	void
 	backoff_reconnect(

--- a/src/rofl/common/openflow/cofaction.cc
+++ b/src/rofl/common/openflow/cofaction.cc
@@ -1978,6 +1978,8 @@ cofaction_set_field::pack(
 	if (buflen < cofaction_set_field::length())
 		throw eInvalid("cofaction_set_field::pack() buflen too short", __FILE__, __PRETTY_FUNCTION__, __LINE__);
 
+	memset(buf,0,buflen);
+
 	cofaction::pack(buf, sizeof(struct rofl::openflow::ofp_action_header));
 
 	switch (get_version()) {


### PR DESCRIPTION
Changes/fixes:
 - crofsock: send_from_queue gets into CPU spin due to out-of-synchronization pending packet count
- crofsock: send_from_queue gets into CPU spin if last send in queue fragments.
- cofaction: (~ line 1980) zero buffer on set_field as OpenVSwitch checks for zero padding.
- note the refactor of 'send_from_buffer()' from logic in 'send_from_queue()'

Thanks!