### PR TITLE
test Makefile cleanup

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = rofl 
+SUBDIRS = rofl
 
 export INCLUDES += -I$(abs_srcdir)/../src/
 

--- a/test/rofl/common/caddress/Makefile.am
+++ b/test/rofl/common/caddress/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 export INCLUDES += -I$(abs_srcdir)/../src/
 
@@ -11,7 +11,7 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit -lpthread
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 #TESTS=unittest
 

--- a/test/rofl/common/caddrinfo/Makefile.am
+++ b/test/rofl/common/caddrinfo/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 export INCLUDES += -I$(abs_srcdir)/../src/
 
@@ -11,7 +11,7 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit -lpthread
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 #TESTS=unittest
 

--- a/test/rofl/common/caddrinfos/Makefile.am
+++ b/test/rofl/common/caddrinfos/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 export INCLUDES += -I$(abs_srcdir)/../src/
 
@@ -11,7 +11,7 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit -lpthread
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 #TESTS=unittest
 

--- a/test/rofl/common/cpacket/Makefile.am
+++ b/test/rofl/common/cpacket/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 export INCLUDES += -I$(abs_srcdir)/../src/
 
@@ -11,7 +11,7 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit -lpthread
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 #TESTS=unittest
 

--- a/test/rofl/common/crofbase/Makefile.am
+++ b/test/rofl/common/crofbase/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 crofbasetest_SOURCES= unittest.cpp crofbasetest.hpp crofbasetest.cpp
 crofbasetest_CPPFLAGS= -I$(top_srcdir)/src/
 crofbasetest_LDFLAGS= -static
-crofbasetest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lpthread -lcppunit 
+crofbasetest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lpthread -lcppunit
 
 #Tests
 

--- a/test/rofl/common/crofchan/Makefile.am
+++ b/test/rofl/common/crofchan/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 crofchantest_SOURCES= unittest.cpp crofchantest.hpp crofchantest.cpp
 crofchantest_CPPFLAGS= -I$(top_srcdir)/src/
 crofchantest_LDFLAGS= -static
-crofchantest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+crofchantest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/crofconn/Makefile.am
+++ b/test/rofl/common/crofconn/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 crofconntest_SOURCES= unittest.cpp crofconntest.hpp crofconntest.cpp
 crofconntest_CPPFLAGS= -I$(top_srcdir)/src/
 crofconntest_LDFLAGS= -static
-crofconntest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+crofconntest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/crofqueue/Makefile.am
+++ b/test/rofl/common/crofqueue/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 crofqueuetest_SOURCES= unittest.cpp crofqueuetest.hpp crofqueuetest.cpp
 crofqueuetest_CPPFLAGS= -I$(top_srcdir)/src/
 crofqueuetest_LDFLAGS= -static
-crofqueuetest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+crofqueuetest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/crofsock/Makefile.am
+++ b/test/rofl/common/crofsock/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 crofsocktest_SOURCES= unittest.cpp crofsocktest.hpp crofsocktest.cpp
 crofsocktest_CPPFLAGS= -I$(top_srcdir)/src/
 crofsocktest_LDFLAGS= -static
-crofsocktest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+crofsocktest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/csegmsg/Makefile.am
+++ b/test/rofl/common/csegmsg/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 export INCLUDES += -I$(abs_srcdir)/../src/
 
@@ -11,7 +11,7 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit -lpthread
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 #TESTS=unittest
 

--- a/test/rofl/common/csockaddr/Makefile.am
+++ b/test/rofl/common/csockaddr/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 export INCLUDES += -I$(abs_srcdir)/../src/
 
@@ -11,7 +11,7 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit -lpthread
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 #TESTS=unittest
 

--- a/test/rofl/common/cthread/Makefile.am
+++ b/test/rofl/common/cthread/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 export INCLUDES += -I$(abs_srcdir)/../src/
 
@@ -11,7 +11,7 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit -lpthread
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 #TESTS=unittest
 

--- a/test/rofl/common/openflow/cofaction/Makefile.am
+++ b/test/rofl/common/openflow/cofaction/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/cofactions/Makefile.am
+++ b/test/rofl/common/openflow/cofactions/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/cofasyncconfig/Makefile.am
+++ b/test/rofl/common/openflow/cofasyncconfig/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/cofbucketcounter/Makefile.am
+++ b/test/rofl/common/openflow/cofbucketcounter/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/cofbucketcounters/Makefile.am
+++ b/test/rofl/common/openflow/cofbucketcounters/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/cofflowmod/Makefile.am
+++ b/test/rofl/common/openflow/cofflowmod/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/cofflowstatsarray/Makefile.am
+++ b/test/rofl/common/openflow/cofflowstatsarray/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/cofgroupdescstatsarray/Makefile.am
+++ b/test/rofl/common/openflow/cofgroupdescstatsarray/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/cofgroupmod/Makefile.am
+++ b/test/rofl/common/openflow/cofgroupmod/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/cofgroupstatsarray/Makefile.am
+++ b/test/rofl/common/openflow/cofgroupstatsarray/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/cofhelloelemversionbitmap/Makefile.am
+++ b/test/rofl/common/openflow/cofhelloelemversionbitmap/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/cofinstruction/Makefile.am
+++ b/test/rofl/common/openflow/cofinstruction/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/cofmeterband/Makefile.am
+++ b/test/rofl/common/openflow/cofmeterband/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/cofmeterbands/Makefile.am
+++ b/test/rofl/common/openflow/cofmeterbands/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/cofmeterbandstats/Makefile.am
+++ b/test/rofl/common/openflow/cofmeterbandstats/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/cofmeterbandstatsarray/Makefile.am
+++ b/test/rofl/common/openflow/cofmeterbandstatsarray/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/cofmeterconfig/Makefile.am
+++ b/test/rofl/common/openflow/cofmeterconfig/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/cofmeterconfigarray/Makefile.am
+++ b/test/rofl/common/openflow/cofmeterconfigarray/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/cofmeterfeatures/Makefile.am
+++ b/test/rofl/common/openflow/cofmeterfeatures/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/cofmeterstats/Makefile.am
+++ b/test/rofl/common/openflow/cofmeterstats/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/cofmeterstatsarray/Makefile.am
+++ b/test/rofl/common/openflow/cofmeterstatsarray/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/cofpacketqueue/Makefile.am
+++ b/test/rofl/common/openflow/cofpacketqueue/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/cofpacketqueues/Makefile.am
+++ b/test/rofl/common/openflow/cofpacketqueues/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/cofportstatsarray/Makefile.am
+++ b/test/rofl/common/openflow/cofportstatsarray/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/cofqueueprop/Makefile.am
+++ b/test/rofl/common/openflow/cofqueueprop/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/cofqueueprops/Makefile.am
+++ b/test/rofl/common/openflow/cofqueueprops/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/cofqueuestatsarray/Makefile.am
+++ b/test/rofl/common/openflow/cofqueuestatsarray/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/cofrole/Makefile.am
+++ b/test/rofl/common/openflow/cofrole/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/coftablefeatureprop/Makefile.am
+++ b/test/rofl/common/openflow/coftablefeatureprop/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/coftablefeatureprops/Makefile.am
+++ b/test/rofl/common/openflow/coftablefeatureprops/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/coftablefeatures/Makefile.am
+++ b/test/rofl/common/openflow/coftablefeatures/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/coftables/Makefile.am
+++ b/test/rofl/common/openflow/coftables/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/coftablestatsarray/Makefile.am
+++ b/test/rofl/common/openflow/coftablestatsarray/Makefile.am
@@ -1,6 +1,6 @@
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = 
+SUBDIRS =
 
 unittest_SOURCES= \
 	unittest.cc \
@@ -9,6 +9,6 @@ unittest_SOURCES= \
 
 unittest_LDADD=$(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
-check_PROGRAMS=unittest 
+check_PROGRAMS=unittest
 
 TESTS=unittest

--- a/test/rofl/common/openflow/coxmatch/Makefile.am
+++ b/test/rofl/common/openflow/coxmatch/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 coxmatchtest_SOURCES= unittest.cpp coxmatchtest.hpp coxmatchtest.cpp
 coxmatchtest_CPPFLAGS= -I$(top_srcdir)/src/
 coxmatchtest_LDFLAGS= -static
-coxmatchtest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+coxmatchtest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/coxmatches/Makefile.am
+++ b/test/rofl/common/openflow/coxmatches/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 coxmatchestest_SOURCES= unittest.cpp coxmatchestest.hpp coxmatchestest.cpp
 coxmatchestest_CPPFLAGS= -I$(top_srcdir)/src/
 coxmatchestest_LDFLAGS= -static
-coxmatchestest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+coxmatchestest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/exceptions/Makefile.am
+++ b/test/rofl/common/openflow/exceptions/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 exceptionstest_SOURCES= unittest.cpp exceptionstest.hpp exceptionstest.cpp
 exceptionstest_CPPFLAGS= -I$(top_srcdir)/src/
 exceptionstest_LDFLAGS= -static
-exceptionstest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+exceptionstest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsgaggrstats/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsgaggrstats/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsgaggrstatstest_SOURCES= unittest.cpp cofmsgaggrstatstest.hpp cofmsgaggrstatstest.cpp
 cofmsgaggrstatstest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsgaggrstatstest_LDFLAGS= -static
-cofmsgaggrstatstest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsgaggrstatstest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsgasyncconfig/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsgasyncconfig/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsgasyncconfigtest_SOURCES= unittest.cpp cofmsgasyncconfigtest.hpp cofmsgasyncconfigtest.cpp
 cofmsgasyncconfigtest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsgasyncconfigtest_LDFLAGS= -static
-cofmsgasyncconfigtest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsgasyncconfigtest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsgbarrier/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsgbarrier/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsgbarriertest_SOURCES= unittest.cpp cofmsgbarriertest.hpp cofmsgbarriertest.cpp
 cofmsgbarriertest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsgbarriertest_LDFLAGS= -static
-cofmsgbarriertest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsgbarriertest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsgconfig/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsgconfig/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsgconfigtest_SOURCES= unittest.cpp cofmsgconfigtest.hpp cofmsgconfigtest.cpp
 cofmsgconfigtest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsgconfigtest_LDFLAGS= -static
-cofmsgconfigtest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsgconfigtest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsgdescstats/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsgdescstats/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsgdescstatstest_SOURCES= unittest.cpp cofmsgdescstatstest.hpp cofmsgdescstatstest.cpp
 cofmsgdescstatstest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsgdescstatstest_LDFLAGS= -static
-cofmsgdescstatstest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsgdescstatstest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsgecho/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsgecho/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsgechotest_SOURCES= unittest.cpp cofmsgechotest.hpp cofmsgechotest.cpp
 cofmsgechotest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsgechotest_LDFLAGS= -static
-cofmsgechotest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsgechotest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsgerror/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsgerror/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsgerrortest_SOURCES= unittest.cpp cofmsgerrortest.hpp cofmsgerrortest.cpp
 cofmsgerrortest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsgerrortest_LDFLAGS= -static
-cofmsgerrortest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsgerrortest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsgexperimenter/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsgexperimenter/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsgexperimentertest_SOURCES= unittest.cpp cofmsgexperimentertest.hpp cofmsgexperimentertest.cpp
 cofmsgexperimentertest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsgexperimentertest_LDFLAGS= -static
-cofmsgexperimentertest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsgexperimentertest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsgexperimenterstats/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsgexperimenterstats/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsgexperimenterstatstest_SOURCES= unittest.cpp cofmsgexperimenterstatstest.hpp cofmsgexperimenterstatstest.cpp
 cofmsgexperimenterstatstest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsgexperimenterstatstest_LDFLAGS= -static
-cofmsgexperimenterstatstest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsgexperimenterstatstest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsgfeatures/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsgfeatures/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsgfeaturestest_SOURCES= unittest.cpp cofmsgfeaturestest.hpp cofmsgfeaturestest.cpp
 cofmsgfeaturestest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsgfeaturestest_LDFLAGS= -static
-cofmsgfeaturestest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsgfeaturestest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsgflowmod/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsgflowmod/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsgflowmodtest_SOURCES= unittest.cpp cofmsgflowmodtest.hpp cofmsgflowmodtest.cpp
 cofmsgflowmodtest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsgflowmodtest_LDFLAGS= -static
-cofmsgflowmodtest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsgflowmodtest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsgflowremoved/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsgflowremoved/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsgflowremovedtest_SOURCES= unittest.cpp cofmsgflowremovedtest.hpp cofmsgflowremovedtest.cpp
 cofmsgflowremovedtest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsgflowremovedtest_LDFLAGS= -static
-cofmsgflowremovedtest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsgflowremovedtest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsgflowstats/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsgflowstats/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsgflowstatstest_SOURCES= unittest.cpp cofmsgflowstatstest.hpp cofmsgflowstatstest.cpp
 cofmsgflowstatstest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsgflowstatstest_LDFLAGS= -static
-cofmsgflowstatstest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsgflowstatstest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsggroupdescstats/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsggroupdescstats/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsggroupdescstatstest_SOURCES= unittest.cpp cofmsggroupdescstatstest.hpp cofmsggroupdescstatstest.cpp
 cofmsggroupdescstatstest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsggroupdescstatstest_LDFLAGS= -static
-cofmsggroupdescstatstest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsggroupdescstatstest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsggroupfeaturesstats/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsggroupfeaturesstats/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsggroupfeaturesstatstest_SOURCES= unittest.cpp cofmsggroupfeaturesstatstest.hpp cofmsggroupfeaturesstatstest.cpp
 cofmsggroupfeaturesstatstest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsggroupfeaturesstatstest_LDFLAGS= -static
-cofmsggroupfeaturesstatstest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsggroupfeaturesstatstest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsggroupmod/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsggroupmod/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsggroupmodtest_SOURCES= unittest.cpp cofmsggroupmodtest.hpp cofmsggroupmodtest.cpp
 cofmsggroupmodtest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsggroupmodtest_LDFLAGS= -static
-cofmsggroupmodtest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsggroupmodtest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsggroupstats/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsggroupstats/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsggroupstatstest_SOURCES= unittest.cpp cofmsggroupstatstest.hpp cofmsggroupstatstest.cpp
 cofmsggroupstatstest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsggroupstatstest_LDFLAGS= -static
-cofmsggroupstatstest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsggroupstatstest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsghello/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsghello/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsghellotest_SOURCES= unittest.cpp cofmsghellotest.hpp cofmsghellotest.cpp
 cofmsghellotest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsghellotest_LDFLAGS= -static
-cofmsghellotest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsghellotest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsgmeterconfigstats/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsgmeterconfigstats/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsgmeterconfigstatstest_SOURCES= unittest.cpp cofmsgmeterconfigstatstest.hpp cofmsgmeterconfigstatstest.cpp
 cofmsgmeterconfigstatstest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsgmeterconfigstatstest_LDFLAGS= -static
-cofmsgmeterconfigstatstest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsgmeterconfigstatstest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsgmeterfeaturesstats/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsgmeterfeaturesstats/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsgmeterfeaturesstatstest_SOURCES= unittest.cpp cofmsgmeterfeaturesstatstest.hpp cofmsgmeterfeaturesstatstest.cpp
 cofmsgmeterfeaturesstatstest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsgmeterfeaturesstatstest_LDFLAGS= -static
-cofmsgmeterfeaturesstatstest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsgmeterfeaturesstatstest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsgmetermod/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsgmetermod/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsgmetermodtest_SOURCES= unittest.cpp cofmsgmetermodtest.hpp cofmsgmetermodtest.cpp
 cofmsgmetermodtest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsgmetermodtest_LDFLAGS= -static
-cofmsgmetermodtest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsgmetermodtest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsgmeterstats/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsgmeterstats/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsgmeterstatstest_SOURCES= unittest.cpp cofmsgmeterstatstest.hpp cofmsgmeterstatstest.cpp
 cofmsgmeterstatstest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsgmeterstatstest_LDFLAGS= -static
-cofmsgmeterstatstest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsgmeterstatstest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsgpacketin/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsgpacketin/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsgpacketintest_SOURCES= unittest.cpp cofmsgpacketintest.hpp cofmsgpacketintest.cpp
 cofmsgpacketintest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsgpacketintest_LDFLAGS= -static
-cofmsgpacketintest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsgpacketintest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsgpacketout/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsgpacketout/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsgpacketouttest_SOURCES= unittest.cpp cofmsgpacketouttest.hpp cofmsgpacketouttest.cpp
 cofmsgpacketouttest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsgpacketouttest_LDFLAGS= -static
-cofmsgpacketouttest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsgpacketouttest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsgportdescstats/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsgportdescstats/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsgportdescstatstest_SOURCES= unittest.cpp cofmsgportdescstatstest.hpp cofmsgportdescstatstest.cpp
 cofmsgportdescstatstest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsgportdescstatstest_LDFLAGS= -static
-cofmsgportdescstatstest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsgportdescstatstest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsgportmod/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsgportmod/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsgportmodtest_SOURCES= unittest.cpp cofmsgportmodtest.hpp cofmsgportmodtest.cpp
 cofmsgportmodtest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsgportmodtest_LDFLAGS= -static
-cofmsgportmodtest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsgportmodtest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsgportstats/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsgportstats/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsgportstatstest_SOURCES= unittest.cpp cofmsgportstatstest.hpp cofmsgportstatstest.cpp
 cofmsgportstatstest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsgportstatstest_LDFLAGS= -static
-cofmsgportstatstest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsgportstatstest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsgportstatus/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsgportstatus/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsgportstatustest_SOURCES= unittest.cpp cofmsgportstatustest.hpp cofmsgportstatustest.cpp
 cofmsgportstatustest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsgportstatustest_LDFLAGS= -static
-cofmsgportstatustest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsgportstatustest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsgqueueconfig/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsgqueueconfig/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsgqueueconfigtest_SOURCES= unittest.cpp cofmsgqueueconfigtest.hpp cofmsgqueueconfigtest.cpp
 cofmsgqueueconfigtest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsgqueueconfigtest_LDFLAGS= -static
-cofmsgqueueconfigtest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsgqueueconfigtest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsgqueuestats/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsgqueuestats/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsgqueuestatstest_SOURCES= unittest.cpp cofmsgqueuestatstest.hpp cofmsgqueuestatstest.cpp
 cofmsgqueuestatstest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsgqueuestatstest_LDFLAGS= -static
-cofmsgqueuestatstest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsgqueuestatstest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsgrole/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsgrole/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsgroletest_SOURCES= unittest.cpp cofmsgroletest.hpp cofmsgroletest.cpp
 cofmsgroletest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsgroletest_LDFLAGS= -static
-cofmsgroletest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsgroletest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsgtablefeaturesstats/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsgtablefeaturesstats/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsgtablefeaturesstatstest_SOURCES= unittest.cpp cofmsgtablefeaturesstatstest.hpp cofmsgtablefeaturesstatstest.cpp
 cofmsgtablefeaturesstatstest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsgtablefeaturesstatstest_LDFLAGS= -static
-cofmsgtablefeaturesstatstest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsgtablefeaturesstatstest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsgtablemod/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsgtablemod/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsgtablemodtest_SOURCES= unittest.cpp cofmsgtablemodtest.hpp cofmsgtablemodtest.cpp
 cofmsgtablemodtest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsgtablemodtest_LDFLAGS= -static
-cofmsgtablemodtest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsgtablemodtest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 

--- a/test/rofl/common/openflow/messages/cofmsgtablestats/Makefile.am
+++ b/test/rofl/common/openflow/messages/cofmsgtablestats/Makefile.am
@@ -8,7 +8,7 @@ AUTOMAKE_OPTIONS = no-dependencies
 cofmsgtablestatstest_SOURCES= unittest.cpp cofmsgtablestatstest.hpp cofmsgtablestatstest.cpp
 cofmsgtablestatstest_CPPFLAGS= -I$(top_srcdir)/src/
 cofmsgtablestatstest_LDFLAGS= -static
-cofmsgtablestatstest_LDADD= -L$(top_builddir)/src/rofl -lrofl_common -lcppunit 
+cofmsgtablestatstest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 


### PR DESCRIPTION
* tests use libtool archrive, that they rebuild in case of a rebuilt
library
* unneeded whitespaces removed