### PR TITLE
crofsock: move call to backoff_reconnect

### DIFF
--- a/src/rofl/common/crofsock.cc
+++ b/src/rofl/common/crofsock.cc
@@ -1760,16 +1760,18 @@ on_error:
     VLOG(2) << "TCP: peer shutdown laddr=" << laddr.str()
             << " raddr=" << raddr.str();
     close();
+
+    if (flag_test(FLAG_RECONNECT_ON_FAILURE)) {
+      backoff_reconnect(true);
+    }
+
     try {
       crofsock_env::call_env(env).handle_closed(*this);
     } catch (std::runtime_error &e) {
       VLOG(1) << __FUNCTION__ << "() caught runtime error, what: %s" << e.what()
               << " laddr=" << laddr.str() << " raddr=" << raddr.str();
     }
-    if (flag_test(FLAG_RECONNECT_ON_FAILURE)) {
-      backoff_reconnect(true);
-    }
-
+    // WARNING: handle_closed might delete this socket, don't call anything here
   } break;
   default: { VLOG(2) << __FUNCTION__ << " error in state=" << state; };
   }


### PR DESCRIPTION
bug report:
==================
WARNING: ThreadSanitizer: heap-use-after-free (pid=31910)
  Read of size 8 at 0x7d780000f398 by thread T3 (mutexes: read M373):
    #0 std::_Base_bitset<1ul>::_M_getword(unsigned long) const /usr/include/c++/5.3.1/bitset:411 (librofl_common.so.0+0x000001dd9ca2)
    #1 std::bitset<32ul>::_Unchecked_test(unsigned long) const /usr/include/c++/5.3.1/bitset:1058 (librofl_common.so.0+0x000001dd9ca2)
    #2 std::bitset<32ul>::test(unsigned long) const /usr/include/c++/5.3.1/bitset:1316 (librofl_common.so.0+0x000001dd9ca2)
    #3 rofl::crofsock::flag_test(int) const ../../../../src/rofl/common/crofsock.h:785 (librofl_common.so.0+0x000001dd9ca2)
    #4 rofl::crofsock::recv_message() ../../../../src/rofl/common/crofsock.cc:1838 (librofl_common.so.0+0x000001dc1386)
    #5 rofl::crofsock::handle_read_event_rxthread(rofl::cthread&, int) ../../../../src/rofl/common/crofsock.cc:1724 (librofl_common.so.0+0x000001dc4828)
    #6 rofl::crofsock::handle_read_event(rofl::cthread&, int) ../../../../src/rofl/common/crofsock.cc:1607 (librofl_common.so.0+0x000001dc7014)
    #7 rofl::cthread::run_loop() ../../../../src/rofl/common/cthread.cpp:579 (librofl_common.so.0+0x000001dfca3e)
    #8 rofl::cthread::start_loop(void*) ../../../../src/rofl/common/cthread.hpp:322 (librofl_common.so.0+0x000001e181f0)
    #9 <null> <null> (libtsan.so.0+0x0000000235b9)

  Previous write of size 8 at 0x7d780000f398 by thread T3:
    #0 operator delete(void*) <null> (libtsan.so.0+0x000000026209)
    #1 rofl::crofconn::~crofconn() ../../../../src/rofl/common/crofconn.cc:34 (librofl_common.so.0+0x000001cc00ed)
    #2 rofl::crofbase::handle_closed(rofl::crofconn&) ../../../../src/rofl/common/crofbase.cc:557 (librofl_common.so.0+0x000001a5c7cc)
    #3 rofl::crofconn::handle_closed(rofl::crofsock&) ../../../../src/rofl/common/crofconn.cc:954 (librofl_common.so.0+0x000001cd32fb)
    #4 rofl::crofsock::recv_message() ../../../../src/rofl/common/crofsock.cc:1833 (librofl_common.so.0+0x000001dc130a)
    #5 rofl::crofsock::handle_read_event_rxthread(rofl::cthread&, int) ../../../../src/rofl/common/crofsock.cc:1724 (librofl_common.so.0+0x000001dc4828)
    #6 rofl::crofsock::handle_read_event(rofl::cthread&, int) ../../../../src/rofl/common/crofsock.cc:1607 (librofl_common.so.0+0x000001dc7014)
    #7 rofl::cthread::run_loop() ../../../../src/rofl/common/cthread.cpp:579 (librofl_common.so.0+0x000001dfca3e)
    #8 rofl::cthread::start_loop(void*) ../../../../src/rofl/common/cthread.hpp:322 (librofl_common.so.0+0x000001e181f0)
    #9 <null> <null> (libtsan.so.0+0x0000000235b9)

  Mutex M373 (0x7d780000f3a0) created at:
    #0 pthread_rwlock_rdlock <null> (libtsan.so.0+0x00000002904d)
    #1 rofl::AcquireReadLock::AcquireReadLock(rofl::crwlock const&) /usr/include/rofl/common/locking.hpp:52 (card+0x0000005dbe3f)
    #2 rofl::crofsock::flag_test(int) const ../../../../src/rofl/common/crofsock.h:779 (librofl_common.so.0+0x000001dd9c2c)
    #3 rofl::crofsock::recv_message() ../../../../src/rofl/common/crofsock.cc:1838 (librofl_common.so.0+0x000001dc1386)
    #4 rofl::crofsock::handle_read_event_rxthread(rofl::cthread&, int) ../../../../src/rofl/common/crofsock.cc:1724 (librofl_common.so.0+0x000001dc4828)
    #5 rofl::crofsock::handle_read_event(rofl::cthread&, int) ../../../../src/rofl/common/crofsock.cc:1607 (librofl_common.so.0+0x000001dc7014)
    #6 rofl::cthread::run_loop() ../../../../src/rofl/common/cthread.cpp:579 (librofl_common.so.0+0x000001dfca3e)
    #7 rofl::cthread::start_loop(void*) ../../../../src/rofl/common/cthread.hpp:322 (librofl_common.so.0+0x000001e181f0)
    #8 <null> <null> (libtsan.so.0+0x0000000235b9)

  Thread T3 (tid=31914, running) created by thread T1 at:
    #0 pthread_create <null> (libtsan.so.0+0x000000027a67)
    #1 rofl::cthread::start() ../../../../src/rofl/common/cthread.cpp:414 (librofl_common.so.0+0x000001def63a)
    #2 rofl::crofsock::crofsock(rofl::crofsock_env*) ../../../../src/rofl/common/crofsock.cc:83 (librofl_common.so.0+0x000001d93e5f)
    #3 rofl::crofconn::crofconn(rofl::crofconn_env*) ../../../../src/rofl/common/crofconn.cc:65 (librofl_common.so.0+0x000001ca3cdc)
    #4 rofl::crofbase::handle_read_event(rofl::cthread&, int) ../../../../src/rofl/common/crofbase.cc:417 (librofl_common.so.0+0x000001a857a4)
    #5 rofl::cthread::run_loop() ../../../../src/rofl/common/cthread.cpp:579 (librofl_common.so.0+0x000001dfca3e)
    #6 rofl::cthread::start_loop(void*) ../../../../src/rofl/common/cthread.hpp:322 (librofl_common.so.0+0x000001e181f0)
    #7 <null> <null> (libtsan.so.0+0x0000000235b9)

SUMMARY: ThreadSanitizer: heap-use-after-free /usr/include/c++/5.3.1/bitset:411 std::_Base_bitset<1ul>::_M_getword(unsigned long) const
==================
==================
WARNING: ThreadSanitizer: heap-use-after-free (pid=31910)
  Read of size 8 at 0x7d780000f3e0 by thread T3:
    #0 rofl::cthread::run_loop() ../../../../src/rofl/common/cthread.cpp:579 (librofl_common.so.0+0x000001dfca56)
    #1 rofl::cthread::start_loop(void*) ../../../../src/rofl/common/cthread.hpp:322 (librofl_common.so.0+0x000001e181f0)
    #2 <null> <null> (libtsan.so.0+0x0000000235b9)

  Previous write of size 8 at 0x7d780000f3e0 by thread T3:
    #0 operator delete(void*) <null> (libtsan.so.0+0x000000026209)
    #1 rofl::crofconn::~crofconn() ../../../../src/rofl/common/crofconn.cc:34 (librofl_common.so.0+0x000001cc00ed)
    #2 rofl::crofbase::handle_closed(rofl::crofconn&) ../../../../src/rofl/common/crofbase.cc:557 (librofl_common.so.0+0x000001a5c7cc)
    #3 rofl::crofconn::handle_closed(rofl::crofsock&) ../../../../src/rofl/common/crofconn.cc:954 (librofl_common.so.0+0x000001cd32fb)
    #4 rofl::crofsock::recv_message() ../../../../src/rofl/common/crofsock.cc:1833 (librofl_common.so.0+0x000001dc130a)
    #5 rofl::crofsock::handle_read_event_rxthread(rofl::cthread&, int) ../../../../src/rofl/common/crofsock.cc:1724 (librofl_common.so.0+0x000001dc4828)
    #6 rofl::crofsock::handle_read_event(rofl::cthread&, int) ../../../../src/rofl/common/crofsock.cc:1607 (librofl_common.so.0+0x000001dc7014)
    #7 rofl::cthread::run_loop() ../../../../src/rofl/common/cthread.cpp:579 (librofl_common.so.0+0x000001dfca3e)
    #8 rofl::cthread::start_loop(void*) ../../../../src/rofl/common/cthread.hpp:322 (librofl_common.so.0+0x000001e181f0)
    #9 <null> <null> (libtsan.so.0+0x0000000235b9)

  Thread T3 (tid=31914, running) created by thread T1 at:
    #0 pthread_create <null> (libtsan.so.0+0x000000027a67)
    #1 rofl::cthread::start() ../../../../src/rofl/common/cthread.cpp:414 (librofl_common.so.0+0x000001def63a)
    #2 rofl::crofsock::crofsock(rofl::crofsock_env*) ../../../../src/rofl/common/crofsock.cc:83 (librofl_common.so.0+0x000001d93e5f)
    #3 rofl::crofconn::crofconn(rofl::crofconn_env*) ../../../../src/rofl/common/crofconn.cc:65 (librofl_common.so.0+0x000001ca3cdc)
    #4 rofl::crofbase::handle_read_event(rofl::cthread&, int) ../../../../src/rofl/common/crofbase.cc:417 (librofl_common.so.0+0x000001a857a4)
    #5 rofl::cthread::run_loop() ../../../../src/rofl/common/cthread.cpp:579 (librofl_common.so.0+0x000001dfca3e)
    #6 rofl::cthread::start_loop(void*) ../../../../src/rofl/common/cthread.hpp:322 (librofl_common.so.0+0x000001e181f0)
    #7 <null> <null> (libtsan.so.0+0x0000000235b9)

SUMMARY: ThreadSanitizer: heap-use-after-free ../../../../src/rofl/common/cthread.cpp:579 rofl::cthread::run_loop()
==================