### PR TITLE
cthread: use pthread_join so finalize a thread

### DIFF
--- a/src/rofl/common/cthread.cpp
+++ b/src/rofl/common/cthread.cpp
@@ -353,16 +353,11 @@ void cthread::stop() {
 
     /* deletion of thread not initiated within this thread */
     if (pthread_self() == tid) {
-      // std::cerr << "pthread_exit" << std::endl;
       return;
     }
 
-    struct timespec ts;
-    ts.tv_nsec = 0;
-    ts.tv_sec = 1;
-    // std::cerr << "pthread_join" << std::endl;
-    if (pthread_timedjoin_np(tid, NULL, &ts) < 0) {
-      // std::cerr << "pthread_cancel" << std::endl;
+    int rv = pthread_join(tid, NULL);
+    if (rv != 0) {
       pthread_cancel(tid);
     }
 


### PR DESCRIPTION
Despite the invalid return value check, pthread_timedjoin_np does not
join in time.