### PR TITLE
crofbase: prevent shadowing of cthread callbacks

### DIFF
--- a/src/rofl/common/crofbase.h
+++ b/src/rofl/common/crofbase.h
@@ -2153,7 +2153,7 @@ private:
 
   static void terminate();
 
-private:
+protected:
   virtual void handle_wakeup(cthread &thread);
 
   virtual void handle_timeout(cthread &thread, uint32_t timer_id);


### PR DESCRIPTION
in case a class inherits from crofbase and the class is having its own
thread, the callbacks to crobase have to be callable.