### PR TITLE
loop optimization in handle_rx_messages

### DIFF
--- a/src/rofl/common/crofconn.cc
+++ b/src/rofl/common/crofconn.cc
@@ -1202,7 +1202,7 @@ void crofconn::handle_rx_messages() {
           }
 
           if ((msg = rxqueues[queue_id].retrieve()) == NULL) {
-            continue; // no further messages in this queue
+            break; // no further messages in this queue
           }
 
           /* segmentation and reassembly */


### PR DESCRIPTION
* break out of loop if 'rxqueues' does not contain any messages instead of looping until 'num < rxweights' is reached