### PR TITLE
remove_ambiguous_get_time

### DIFF
--- a/src/rofl/common/ctimespec.hpp
+++ b/src/rofl/common/ctimespec.hpp
@@ -206,28 +206,6 @@ public:
   /**
    *
    */
-  ctimespec &get_time() {
-    // get current time
-    if (clock_gettime(clk_id.get_clkid(), &tspec) < 0) {
-      switch (errno) {
-      case EFAULT: {
-        throw eTimeSpecSysCall("ctimespec::now() invalid struct timespec");
-      } break;
-      case EINVAL: {
-        throw eTimeSpecSysCall("ctimespec::now() clockid_t is invalid");
-      } break;
-      default: {
-        throw eTimeSpecSysCall("ctimespec::now() unknown internal error on "
-                               "syscall clock_gettime()");
-      };
-      }
-    }
-    return *this;
-  };
-
-  /**
-   *
-   */
   ctimespec &get_time(const cclockid &clk_id = cclockid(CLOCK_MONOTONIC)) {
     // get current time
     if (clock_gettime(clk_id.get_clkid(), &tspec) < 0) {


### PR DESCRIPTION
* `get_time()` has been removed because it will never be used because `get_time(const cclockid &clk_id =  clockid(CLOCK_MONOTONIC))` does have a default parameter set and basically does the same