### PR TITLE
rofl threading rework and cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,5 @@ branches:
 notifications:
   email:
     - andreas.koepsel@bisdn.de
+  slack:
+    secure: XATCKlM3rAr3QUQ5DycBN14CzlMuP1G/lt5kZon8hSM5gweN+GjhK10ypG0cjpZomwEYiDcmH9hCWAolrUQaIU4QMNFYyiy6w2BARJiC7LMo5YhOT+8jOLGAdOUjOjGC2xEyYP/VAolyYGYq5wiRkHi6fhoseQ0+FWRDZtCM64g=

--- a/examples/controller/controller.cpp
+++ b/examples/controller/controller.cpp
@@ -60,7 +60,7 @@ int controller::run(int argc, char **argv) {
     struct timespec ts;
     ts.tv_sec = 2;
     ts.tv_nsec = 0;
-    pselect(0, NULL, NULL, NULL, &ts, NULL);
+    pselect(0, nullptr, nullptr, nullptr, &ts, nullptr);
   }
 
   return 0;

--- a/examples/datapath/datapath.cpp
+++ b/examples/datapath/datapath.cpp
@@ -41,7 +41,7 @@ int datapath::run(int argc, char **argv) {
     struct timespec ts;
     ts.tv_sec = 2;
     ts.tv_nsec = 0;
-    pselect(0, NULL, NULL, NULL, &ts, NULL);
+    pselect(0, nullptr, nullptr, nullptr, &ts, nullptr);
   }
 
   crofbase::set_ctl(ctlid).close();

--- a/examples/ethswctld/cdaemon.cc
+++ b/examples/ethswctld/cdaemon.cc
@@ -56,7 +56,7 @@ void cdaemon::daemonize(std::string const &pidfile,
     if (sigfillset(&sigset) < 0) {
       throw rofl::eSysCall("sigfillset()");
     }
-    if (sigprocmask(SIG_UNBLOCK, &sigset, NULL) < 0) {
+    if (sigprocmask(SIG_UNBLOCK, &sigset, nullptr) < 0) {
       throw rofl::eSysCall("sigprocmask()");
     }
 

--- a/examples/ethswctld/cdaemon.h
+++ b/examples/ethswctld/cdaemon.h
@@ -17,7 +17,6 @@
 #include <sys/resource.h>
 #include <sys/stat.h>
 #include <sys/time.h>
-#include <sys/time.h>
 #include <sys/types.h>
 #include <unistd.h>
 

--- a/examples/ethswctld/cetherswitch.cc
+++ b/examples/ethswctld/cetherswitch.cc
@@ -80,7 +80,9 @@ cetherswitch::cetherswitch(
   thread.start("cetherswitch");
 }
 
-cetherswitch::~cetherswitch() {}
+cetherswitch::~cetherswitch() {
+  thread.drop_timer(this, rofl::cthread::ALL_TIMERS);
+}
 
 void cetherswitch::handle_timeout(void *userdata) {
   try {

--- a/examples/ethswctld/cetherswitch.cc
+++ b/examples/ethswctld/cetherswitch.cc
@@ -62,7 +62,7 @@ int cetherswitch::run(int argc, char **argv) {
       struct timespec ts;
       ts.tv_sec = 1;
       ts.tv_nsec = 0;
-      pselect(0, NULL, NULL, NULL, &ts, NULL);
+      pselect(0, nullptr, nullptr, nullptr, &ts, nullptr);
     } catch (std::runtime_error &e) {
       std::cerr << "exception caught, what: " << e.what() << std::endl;
     }

--- a/examples/ethswctld/cetherswitch.cc
+++ b/examples/ethswctld/cetherswitch.cc
@@ -73,7 +73,7 @@ int cetherswitch::run(int argc, char **argv) {
 
 cetherswitch::cetherswitch(
     const rofl::openflow::cofhello_elem_versionbitmap &versionbitmap)
-    : thread(this), dump_fib_interval(DUMP_FIB_DEFAULT_INTERVAL),
+    : dump_fib_interval(DUMP_FIB_DEFAULT_INTERVAL),
       get_flow_stats_interval(GET_FLOW_STATS_DEFAULT_INTERVAL) {
   rofl::crofbase::set_versionbitmap(versionbitmap);
 
@@ -82,13 +82,14 @@ cetherswitch::cetherswitch(
 
 cetherswitch::~cetherswitch() {}
 
-void cetherswitch::handle_timeout(cthread &thread, uint32_t timer_id) {
+void cetherswitch::handle_timeout(void *userdata) {
   try {
+    int timer_id = (long)userdata;
     switch (timer_id) {
     case TIMER_ID_DUMP_FIB: {
 
       // re-register timer for next round
-      thread.add_timer(TIMER_ID_DUMP_FIB,
+      thread.add_timer(this, TIMER_ID_DUMP_FIB,
                        rofl::ctimespec().expire_in(dump_fib_interval));
 
       std::cerr << "****************************************" << std::endl;
@@ -99,7 +100,7 @@ void cetherswitch::handle_timeout(cthread &thread, uint32_t timer_id) {
     case TIMER_ID_GET_FLOW_STATS: {
 
       // re-register timer for next round
-      thread.add_timer(TIMER_ID_GET_FLOW_STATS,
+      thread.add_timer(this, TIMER_ID_GET_FLOW_STATS,
                        rofl::ctimespec().expire_in(get_flow_stats_interval));
 
       rofl::crofdpt &dpt = rofl::crofbase::set_dpt(dptid);
@@ -132,11 +133,11 @@ void cetherswitch::handle_timeout(cthread &thread, uint32_t timer_id) {
  */
 void cetherswitch::handle_dpt_open(rofl::crofdpt &dpt) {
   // register timer for dumping ethswitch's internal state
-  thread.add_timer(TIMER_ID_DUMP_FIB,
+  thread.add_timer(this, TIMER_ID_DUMP_FIB,
                    rofl::ctimespec().expire_in(dump_fib_interval));
 
   // start periodic timer for querying datapath for all flow table entries
-  thread.add_timer(TIMER_ID_GET_FLOW_STATS,
+  thread.add_timer(this, TIMER_ID_GET_FLOW_STATS,
                    rofl::ctimespec().expire_in(get_flow_stats_interval));
 
   dptid = dpt.get_dptid();
@@ -183,9 +184,9 @@ void cetherswitch::handle_dpt_open(rofl::crofdpt &dpt) {
 }
 
 void cetherswitch::handle_dpt_close(const rofl::cdptid &dptid) {
-  thread.drop_timer(TIMER_ID_DUMP_FIB);
+  thread.drop_timer(this, TIMER_ID_DUMP_FIB);
 
-  thread.drop_timer(TIMER_ID_GET_FLOW_STATS);
+  thread.drop_timer(this, TIMER_ID_GET_FLOW_STATS);
 
   std::cerr << "[cetherswitch] datapath detached, dptid: " << dptid << std::endl
             << cfibtable::get_fib(dptid);

--- a/examples/ethswctld/cetherswitch.h
+++ b/examples/ethswctld/cetherswitch.h
@@ -25,9 +25,7 @@ namespace ethswctld {
  * A simple controller application capable of switching Ethernet
  * frames in a flow-based manner.
  */
-class cetherswitch : public cflowtable_env,
-                     public rofl::crofbase,
-                     public virtual rofl::cthread_env {
+class cetherswitch : public cflowtable_env, public rofl::crofbase {
 public:
   /**
    * @brief	Static main routine for class cetherswitch
@@ -69,7 +67,7 @@ private:
    *
    * @param dpt datapath instance
    */
-  virtual void handle_dpt_open(rofl::crofdpt &dpt);
+  void handle_dpt_open(rofl::crofdpt &dpt) override;
 
   /**
    * @brief	Called after termination of associated OpenFlow control channel.
@@ -82,7 +80,7 @@ private:
    *
    * @param dpt datapath instance
    */
-  virtual void handle_dpt_close(const rofl::cdptid &dptid);
+  void handle_dpt_close(const rofl::cdptid &dptid) override;
 
   /**
    * @brief	OpenFlow Packet-In message received.
@@ -91,8 +89,8 @@ private:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_packet_in(rofl::crofdpt &dpt, const rofl::cauxid &auxid,
-                                rofl::openflow::cofmsg_packet_in &msg);
+  void handle_packet_in(rofl::crofdpt &dpt, const rofl::cauxid &auxid,
+                        rofl::openflow::cofmsg_packet_in &msg) override;
 
   /**
    * @brief	OpenFlow Flow-Stats-Reply message received.
@@ -101,9 +99,9 @@ private:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void
-  handle_flow_stats_reply(rofl::crofdpt &dpt, const rofl::cauxid &auxid,
-                          rofl::openflow::cofmsg_flow_stats_reply &msg);
+  void handle_flow_stats_reply(
+      rofl::crofdpt &dpt, const rofl::cauxid &auxid,
+      rofl::openflow::cofmsg_flow_stats_reply &msg) override;
 
   /**
    * @brief	Timer expired while waiting for OpenFlow Flow-Stats-Reply
@@ -115,8 +113,8 @@ private:
    * @param dpt datapath instance
    * @param xid OpenFlow transaction identifier
    */
-  virtual void handle_flow_stats_reply_timeout(rofl::crofdpt &dpt,
-                                               uint32_t xid);
+  void handle_flow_stats_reply_timeout(rofl::crofdpt &dpt,
+                                       uint32_t xid) override;
 
   /** @endcond */
 
@@ -129,7 +127,7 @@ private:
    * @param opaque expired timer type
    * @param data pointer to opaque data
    */
-  virtual void handle_timeout(cthread &thread, uint32_t timer_id);
+  void handle_timeout(void *userdata) override;
 
   /**
    * @brief	Dump an Ethernet frame received via an OpenFlow Packet-In
@@ -141,7 +139,7 @@ private:
   /**
    *
    */
-  virtual rofl::crofdpt &set_dpt(const rofl::cdptid &dptid) {
+  rofl::crofdpt &set_dpt(const rofl::cdptid &dptid) override {
     return rofl::crofbase::set_dpt(dptid);
   };
 

--- a/examples/ethswctld/cfibentry.cc
+++ b/examples/ethswctld/cfibentry.cc
@@ -13,8 +13,8 @@ using namespace rofl::examples::ethswctld;
 cfibentry::cfibentry(cfibentry_env *fibenv, const rofl::caddress_ll &hwaddr,
                      uint32_t port_no)
     : env(fibenv), port_no(port_no), hwaddr(hwaddr),
-      entry_timeout(CFIBENTRY_DEFAULT_TIMEOUT), thread(this) {
-  thread.add_timer(TIMER_ID_ENTRY_EXPIRED,
+      entry_timeout(CFIBENTRY_DEFAULT_TIMEOUT) {
+  thread.add_timer(this, TIMER_ID_ENTRY_EXPIRED,
                    rofl::ctimespec().expire_in(entry_timeout));
   std::cerr << "[cfibentry] created" << std::endl << *this;
   thread.start("cfibentry");
@@ -24,7 +24,8 @@ cfibentry::~cfibentry() {
   std::cerr << "[cfibentry] deleted" << std::endl << *this;
 }
 
-void cfibentry::handle_timeout(cthread &thread, uint32_t timer_id) {
+void cfibentry::handle_timeout(void *userdata) {
+  int timer_id = (long)userdata;
   switch (timer_id) {
   case TIMER_ID_ENTRY_EXPIRED: {
     env->fib_timer_expired(hwaddr);
@@ -39,6 +40,6 @@ void cfibentry::set_port_no(uint32_t port_no) {
     env->fib_port_update(*this);
   }
 
-  thread.add_timer(TIMER_ID_ENTRY_EXPIRED,
+  thread.add_timer(this, TIMER_ID_ENTRY_EXPIRED,
                    rofl::ctimespec().expire_in(entry_timeout));
 }

--- a/examples/ethswctld/cfibentry.cc
+++ b/examples/ethswctld/cfibentry.cc
@@ -22,6 +22,7 @@ cfibentry::cfibentry(cfibentry_env *fibenv, const rofl::caddress_ll &hwaddr,
 
 cfibentry::~cfibentry() {
   std::cerr << "[cfibentry] deleted" << std::endl << *this;
+  thread.drop_timer(this, rofl::cthread::ALL_TIMERS);
 }
 
 void cfibentry::handle_timeout(void *userdata) {

--- a/examples/ethswctld/cfibentry.h
+++ b/examples/ethswctld/cfibentry.h
@@ -98,7 +98,7 @@ protected:
  * has become stale. For timer support, cfibentry derives from class
  * rofl::ciosrv.
  */
-class cfibentry : public rofl::cthread_env {
+class cfibentry : public cthread_timeout_event {
 public:
   /**
    * @brief	cfibentry constructor
@@ -159,10 +159,7 @@ private:
    *
    * @see rofl::ciosrv
    */
-  void handle_timeout(cthread &thread, uint32_t timer_id) override;
-  void handle_read_event(cthread &thread, int fd) override {}
-  void handle_write_event(cthread &thread, int fd) override {}
-  void handle_wakeup(cthread &thread) override {}
+  void handle_timeout(void *userdata) override;
 
 public:
   /**

--- a/examples/ethswctld/cflowentry.cc
+++ b/examples/ethswctld/cflowentry.cc
@@ -24,6 +24,7 @@ cflowentry::cflowentry(cflowentry_env *flowenv, const rofl::cdptid &dptid,
 cflowentry::~cflowentry() {
   std::cerr << "[cflowentry] deleted" << std::endl << *this;
   flow_mod_delete();
+  thread.drop_timer(this, rofl::cthread::ALL_TIMERS);
 }
 
 void cflowentry::handle_timeout(void *userdata) {

--- a/examples/ethswctld/cflowentry.h
+++ b/examples/ethswctld/cflowentry.h
@@ -103,7 +103,7 @@ public:
  *
  * @see cflowentry_env
  */
-class cflowentry : public rofl::cthread_env {
+class cflowentry : public cthread_timeout_event {
 public:
   /**
    * @brief	cflowentry constructor
@@ -170,10 +170,7 @@ private:
   void flow_mod_modify();
 
 private:
-  void handle_timeout(cthread &thread, uint32_t timer_id) override;
-  void handle_read_event(cthread &thread, int fd) override {}
-  void handle_write_event(cthread &thread, int fd) override {}
-  void handle_wakeup(cthread &thread) override {}
+  void handle_timeout(void *userdata) override;
 
 public:
   /**

--- a/examples/ethswctld/cunixenv.h
+++ b/examples/ethswctld/cunixenv.h
@@ -16,7 +16,6 @@
 #include <string>
 #include <sys/resource.h>
 #include <sys/stat.h>
-#include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/types.h>
 #include <unistd.h>

--- a/examples/ethswctld/cunixenv.h
+++ b/examples/ethswctld/cunixenv.h
@@ -68,7 +68,7 @@ public:
   /**
    * Constructor
    */
-  cunixenv(int argc = 0, char **argv = NULL);
+  cunixenv(int argc = 0, char **argv = nullptr);
 
   /**
    * Destructor

--- a/examples/tcpclient/tcpclient.h
+++ b/examples/tcpclient/tcpclient.h
@@ -49,7 +49,7 @@ public:
       struct timespec ts;
       ts.tv_sec = 2;
       ts.tv_nsec = 0;
-      pselect(0, NULL, NULL, NULL, &ts, NULL);
+      pselect(0, nullptr, nullptr, nullptr, &ts, nullptr);
     }
 
     crofbase::set_ctl(ctlid).close();

--- a/examples/tcpserver/tcpserver.h
+++ b/examples/tcpserver/tcpserver.h
@@ -48,7 +48,7 @@ public:
       struct timespec ts;
       ts.tv_sec = 2;
       ts.tv_nsec = 0;
-      pselect(0, NULL, NULL, NULL, &ts, NULL);
+      pselect(0, nullptr, nullptr, nullptr, &ts, nullptr);
     }
 
     return 0;

--- a/src/rofl/common/Makefile.am
+++ b/src/rofl/common/Makefile.am
@@ -5,52 +5,51 @@ SUBDIRS = openflow
 noinst_LTLIBRARIES = librofl_common_base.la
 
 librofl_common_base_la_SOURCES = \
-		rofcommon.h \
-		exception.hpp \
-		locking.hpp \
+		callbacks.hpp \
+		caddress.cc \
+		caddress.h \
+		caddrinfo.cc \
+		caddrinfo.h \
+		caddrinfos.cc \
+		caddrinfos.h \
+		cauxid.h \
+		cctlid.h \
+		cdpid.h \
+		cdptid.h \
+		cindex.h \
+		cmemory.cc \
+		cmemory.h \
+		cpacket.cc \
+		cpacket.h \
+		crandom.cc \
+		crandom.h \
 		crofbase.cc \
 		crofbase.h \
-		crofdpt.cc \
-		crofdpt.h \
-		crofctl.cc \
-		crofctl.h \
 		crofchan.cc \
 		crofchan.h \
 		crofconn.cc \
 		crofconn.h \
+		crofctl.cc \
+		crofctl.h \
+		crofdpt.cc \
+		crofdpt.h \
+		crofqueue.h \
 		crofsock.cc \
 		crofsock.h \
-		crofqueue.h \
-		ctimespec.cpp \
-		ctimespec.hpp \
-		ctimer.cpp \
-		ctimer.hpp \
+		csegment.cpp \
+		csegment.hpp \
+		csockaddr.cc \
+		csockaddr.h \
 		cthread.cpp \
 		cthread.hpp \
+		ctimer.cpp \
+		ctimer.hpp \
+		ctimespec.cpp \
+		ctimespec.hpp \
 		endian_conversion.h \
-		caddress.h \
-		caddress.cc \
-		cpacket.h \
-		cpacket.cc \
-		crandom.h \
-		crandom.cc \
-		cmemory.h \
-		cmemory.cc \
-		cauxid.h \
-		cctlid.h \
-		cdptid.h \
-		csockaddr.h \
-		csockaddr.cc \
-		caddrinfo.h \
-		caddrinfo.cc \
-		caddrinfos.h \
-		caddrinfos.cc \
-		cindex.h \
-		cdpid.h \
-		csegment.hpp \
-		csegment.cpp
-
-		
+		exception.hpp \
+		locking.hpp \
+		rofcommon.h
 
 librofl_common_base_la_LIBADD=openflow/libopenflow.la -lrt
 

--- a/src/rofl/common/Makefile.am
+++ b/src/rofl/common/Makefile.am
@@ -85,4 +85,4 @@ library_include_HEADERS= \
 
 
 
-AM_CPPFLAGS=-fPIC -Wno-error=deprecated-declarations
+AM_CPPFLAGS=-fPIC

--- a/src/rofl/common/caddress.cc
+++ b/src/rofl/common/caddress.cc
@@ -92,7 +92,7 @@ std::string caddress_in4::addr2str() const {
   memset(buf, 0, sizeof(buf));
   struct in_addr in4addr;
   memcpy((uint8_t *)&(in4addr.s_addr), cmemory::somem(), INET4_ADDR_LEN);
-  if (inet_ntop(AF_INET, (const void *)&in4addr, buf, sizeof(buf)) == NULL) {
+  if (inet_ntop(AF_INET, (const void *)&in4addr, buf, sizeof(buf)) == nullptr) {
     throw eSysCall("inet_ntop()");
   }
   return std::string(buf);
@@ -112,7 +112,7 @@ std::string caddress_in6::addr2str() const {
   memset(buf, 0, sizeof(buf));
   struct in6_addr in6addr;
   memcpy((uint8_t *)&(in6addr.s6_addr), cmemory::somem(), INET6_ADDR_LEN);
-  if (inet_ntop(AF_INET6, (const void *)&in6addr, buf, sizeof(buf)) == NULL) {
+  if (inet_ntop(AF_INET6, (const void *)&in6addr, buf, sizeof(buf)) == nullptr) {
     throw eSysCall("inet_ntop()");
   }
   return std::string(buf);

--- a/src/rofl/common/caddrinfos.cc
+++ b/src/rofl/common/caddrinfos.cc
@@ -16,13 +16,13 @@ void caddrinfos::resolve() {
   ai_hints.ai_socktype = hints.get_ai_socktype();
   ai_hints.ai_flags = hints.get_ai_flags();
   ai_hints.ai_protocol = hints.get_ai_protocol();
-  ai_hints.ai_addr = NULL;
+  ai_hints.ai_addr = nullptr;
   ai_hints.ai_addrlen = 0;
 
   struct addrinfo *result, *rp = (struct addrinfo *)0;
 
-  int rc = getaddrinfo((node.empty()) ? NULL : node.c_str(),
-                       (service.empty()) ? NULL : service.c_str(), &ai_hints,
+  int rc = getaddrinfo((node.empty()) ? nullptr : node.c_str(),
+                       (service.empty()) ? nullptr : service.c_str(), &ai_hints,
                        &result);
   if (rc != 0) {
     switch (rc) {
@@ -48,7 +48,7 @@ void caddrinfos::resolve() {
 
   unsigned int index = 0;
 
-  for (rp = result; rp != NULL; rp = rp->ai_next) {
+  for (rp = result; rp != nullptr; rp = rp->ai_next) {
     add_addr_info(index++).unpack(rp, sizeof(*rp));
   }
 

--- a/src/rofl/common/callbacks.hpp
+++ b/src/rofl/common/callbacks.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+namespace rofl {
+
+class cthread_write_event {
+public:
+  cthread_write_event() {}
+  virtual ~cthread_write_event() {}
+  virtual void handle_write(int fd, void *userdata) = 0;
+};
+
+class cthread_read_event {
+public:
+  cthread_read_event() {}
+  virtual ~cthread_read_event() {}
+  virtual void handle_read(int fd, void *userdata) = 0;
+};
+
+class cthread_timeout_event {
+public:
+  cthread_timeout_event() {}
+  virtual ~cthread_timeout_event() {}
+  virtual void handle_timeout(void *userdata) = 0;
+};
+
+class cthread_wakeup_event {
+public:
+  cthread_wakeup_event() {}
+  virtual ~cthread_wakeup_event() {}
+  virtual void handle_wakeup(void *userdata) = 0;
+};
+
+}; // end of namespace rofl

--- a/src/rofl/common/cmemory.cc
+++ b/src/rofl/common/cmemory.cc
@@ -11,11 +11,11 @@ using namespace rofl;
 /*static*/ int cmemory::memlockcnt = 0;
 
 cmemory::cmemory(size_t len)
-    : data(std::make_pair<uint8_t *, size_t>(NULL, 0)) {
+    : data(std::make_pair<uint8_t *, size_t>(nullptr, 0)) {
 #if 0
 	if (0 == cmemory::memlockcnt)
 	{
-		pthread_mutex_init(&cmemory::memlock, NULL);
+		pthread_mutex_init(&cmemory::memlock, nullptr);
 	}
 	++cmemory::memlockcnt;
 #endif
@@ -26,11 +26,11 @@ cmemory::cmemory(size_t len)
 }
 
 cmemory::cmemory(uint8_t *data, size_t datalen)
-    : data(std::make_pair<uint8_t *, size_t>(NULL, 0)) {
+    : data(std::make_pair<uint8_t *, size_t>(nullptr, 0)) {
 #if 0
 	if (0 == cmemory::memlockcnt)
 	{
-		pthread_mutex_init(&cmemory::memlock, NULL);
+		pthread_mutex_init(&cmemory::memlock, nullptr);
 	}
 	++cmemory::memlockcnt;
 #endif
@@ -42,11 +42,11 @@ cmemory::cmemory(uint8_t *data, size_t datalen)
 }
 
 cmemory::cmemory(const cmemory &m)
-    : data(std::make_pair<uint8_t *, size_t>(NULL, 0)) {
+    : data(std::make_pair<uint8_t *, size_t>(nullptr, 0)) {
 #if 0
 	if (0 == cmemory::memlockcnt)
 	{
-		pthread_mutex_init(&cmemory::memlock, NULL);
+		pthread_mutex_init(&cmemory::memlock, nullptr);
 	}
 	++cmemory::memlockcnt;
 #endif
@@ -243,7 +243,7 @@ void cmemory::mfree() {
     memset(data.first, 0, data.second);
     free(data.first);
   }
-  data = std::make_pair<uint8_t *, size_t>(NULL, 0);
+  data = std::make_pair<uint8_t *, size_t>(nullptr, 0);
 }
 
 uint8_t *cmemory::insert(uint8_t *ptr, size_t len) {
@@ -268,7 +268,7 @@ uint8_t *cmemory::insert(unsigned int offset, size_t len) {
     return somem();
   }
 
-  uint8_t *p_ptr = (uint8_t *)0;
+  uint8_t *p_ptr = nullptr;
   size_t p_len = data.second + len;
 
   if ((p_ptr = (uint8_t *)calloc(1, p_len)) == 0) {

--- a/src/rofl/common/crofbase.cc
+++ b/src/rofl/common/crofbase.cc
@@ -19,6 +19,9 @@ using namespace rofl;
 /*static*/ crwlock crofbase::rofbases_rwlock;
 
 crofbase::~crofbase() {
+  /* drop all timers */
+  thread.drop_timer(this, cthread::ALL_TIMERS);
+
   /* close listening sockets */
   close_dpt_socks();
   close_ctl_socks();

--- a/src/rofl/common/crofbase.h
+++ b/src/rofl/common/crofbase.h
@@ -42,10 +42,12 @@ public:
   eRofBaseNotConnected(const std::string &__arg) : eRofBaseBase(__arg){};
 };
 
-class crofbase : public virtual rofl::cthread_env,
-                 public rofl::crofconn_env,
-                 public rofl::crofctl_env,
-                 public rofl::crofdpt_env {
+class crofbase : public cthread_read_event,
+                 /*cthread_write_event,*/
+                 public cthread_timeout_event,
+                 public crofconn_env,
+                 public crofctl_env,
+                 public crofdpt_env {
   // map of active crofbase instances
   static std::set<crofbase *> rofbases;
 
@@ -221,8 +223,7 @@ public:
     dpt_sockets[baddr] = listen(baddr);
 
     /* instruct thread to read from socket descriptor */
-    thread.add_fd(dpt_sockets[baddr]);
-    thread.add_read_fd(dpt_sockets[baddr], false);
+    thread.add_read_fd(dpt_sockets[baddr], this, nullptr, false);
   };
 
   /**
@@ -291,8 +292,7 @@ public:
     ctl_sockets[baddr] = listen(baddr);
 
     /* instruct thread to read from socket descriptor */
-    thread.add_fd(ctl_sockets[baddr]);
-    thread.add_read_fd(ctl_sockets[baddr], false);
+    thread.add_read_fd(ctl_sockets[baddr], this, nullptr, false);
   };
 
   /**
@@ -357,8 +357,8 @@ public:
       rofdpts_deletion.insert(it.second);
     }
     rofdpts.clear();
-    if (not thread.has_timer(TIMER_ID_ROFDPT_DESTROY)) {
-      thread.add_timer(TIMER_ID_ROFDPT_DESTROY, ctimespec().expire_in(8));
+    if (not thread.has_timer(this, TIMER_ID_ROFDPT_DESTROY)) {
+      thread.add_timer(this, TIMER_ID_ROFDPT_DESTROY, ctimespec().expire_in(8));
     }
   };
 
@@ -389,7 +389,7 @@ public:
     while (rofdpts.find(id) != rofdpts.end()) {
       id++;
     }
-    rofdpts[id] = new crofdpt(this, id);
+    rofdpts[id] = new crofdpt(&thread, this, id);
     return *(rofdpts[id]);
   };
 
@@ -420,7 +420,7 @@ public:
       delete rofdpts[dptid];
       rofdpts.erase(dptid);
     }
-    rofdpts[dptid] = new crofdpt(this, dptid);
+    rofdpts[dptid] = new crofdpt(&thread, this, dptid);
     return *(rofdpts[dptid]);
   };
 
@@ -443,7 +443,7 @@ public:
     if (rofdpts.find(dptid) == rofdpts.end()) {
       if (raise)
         throw eRofBaseNotFound("rofl::crofbase::set_dpt() dptid not found");
-      rofdpts[dptid] = new crofdpt(this, dptid);
+      rofdpts[dptid] = new crofdpt(&thread, this, dptid);
     }
     return *(rofdpts[dptid]);
   };
@@ -487,8 +487,8 @@ public:
     /* mark its dptid as free */
     rofdpts.erase(dptid);
     /* trigger management thread for doing the clean-up work */
-    if (not thread.has_timer(TIMER_ID_ROFDPT_DESTROY)) {
-      thread.add_timer(TIMER_ID_ROFDPT_DESTROY, ctimespec().expire_in(8));
+    if (not thread.has_timer(this, TIMER_ID_ROFDPT_DESTROY)) {
+      thread.add_timer(this, TIMER_ID_ROFDPT_DESTROY, ctimespec().expire_in(8));
     }
     return true;
   };
@@ -536,7 +536,7 @@ public:
     while (rofdpts.find(id) != rofdpts.end()) {
       id++;
     }
-    rofdpts[id] = new crofdpt(this, id);
+    rofdpts[id] = new crofdpt(&thread, this, id);
     return *(rofdpts[id]);
   };
 
@@ -593,8 +593,8 @@ public:
       rofctls_deletion.insert(it.second);
     }
     rofctls.clear();
-    if (not thread.has_timer(TIMER_ID_ROFCTL_DESTROY)) {
-      thread.add_timer(TIMER_ID_ROFCTL_DESTROY, ctimespec().expire_in(8));
+    if (not thread.has_timer(this, TIMER_ID_ROFCTL_DESTROY)) {
+      thread.add_timer(this, TIMER_ID_ROFCTL_DESTROY, ctimespec().expire_in(8));
     }
   };
 
@@ -624,7 +624,7 @@ public:
     while (rofctls.find(cctlid(id)) != rofctls.end()) {
       id++;
     }
-    rofctls[cctlid(id)] = new crofctl(this, cctlid(id));
+    rofctls[cctlid(id)] = new crofctl(&thread, this, cctlid(id));
     return *(rofctls[cctlid(id)]);
   };
 
@@ -655,7 +655,7 @@ public:
       delete rofctls[ctlid];
       rofctls.erase(ctlid);
     }
-    rofctls[ctlid] = new crofctl(this, ctlid);
+    rofctls[ctlid] = new crofctl(&thread, this, ctlid);
     return *(rofctls[ctlid]);
   };
 
@@ -678,7 +678,7 @@ public:
     if (rofctls.find(ctlid) == rofctls.end()) {
       if (raise)
         throw eRofBaseNotFound("rofl::crofbase::set_ctl() ctlid not found");
-      rofctls[ctlid] = new crofctl(this, ctlid);
+      rofctls[ctlid] = new crofctl(&thread, this, ctlid);
     }
     return *(rofctls[ctlid]);
   };
@@ -722,8 +722,8 @@ public:
     /* mark its ctlid as free */
     rofctls.erase(ctlid);
     /* trigger management thread for doing the clean-up work */
-    if (not thread.has_timer(TIMER_ID_ROFCTL_DESTROY)) {
-      thread.add_timer(TIMER_ID_ROFCTL_DESTROY, ctimespec().expire_in(8));
+    if (not thread.has_timer(this, TIMER_ID_ROFCTL_DESTROY)) {
+      thread.add_timer(this, TIMER_ID_ROFCTL_DESTROY, ctimespec().expire_in(8));
     }
     return true;
   };
@@ -880,8 +880,8 @@ public:
   /**@}*/
 
 private:
-  virtual void role_request_rcvd(rofl::crofctl &ctl, uint32_t role,
-                                 uint64_t rcvd_generation_id);
+  void role_request_rcvd(crofctl &ctl, uint32_t role,
+                         uint64_t rcvd_generation_id) override;
 
 public:
   /**
@@ -1146,9 +1146,8 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void
-  handle_features_reply(rofl::crofdpt &dpt, const rofl::cauxid &auxid,
-                        rofl::openflow::cofmsg_features_reply &msg){};
+  void handle_features_reply(crofdpt &dpt, const cauxid &auxid,
+                             openflow::cofmsg_features_reply &msg) override{};
 
   /**
    * @brief	Timer expired while waiting for OpenFlow Features-Reply message.
@@ -1159,8 +1158,7 @@ public:
    * @param dpt datapath instance
    * @param xid OpenFlow transaction identifier
    */
-  virtual void handle_features_reply_timeout(rofl::crofdpt &dpt,
-                                             uint32_t xid){};
+  void handle_features_reply_timeout(crofdpt &dpt, uint32_t xid) override{};
 
   /**
    * @brief	OpenFlow Get-Config-Reply message received.
@@ -1169,9 +1167,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void
-  handle_get_config_reply(rofl::crofdpt &dpt, const rofl::cauxid &auxid,
-                          rofl::openflow::cofmsg_get_config_reply &msg){};
+  void
+  handle_get_config_reply(crofdpt &dpt, const cauxid &auxid,
+                          openflow::cofmsg_get_config_reply &msg) override{};
 
   /**
    * @brief	Timer expired while waiting for OpenFlow Get-Config-Reply
@@ -1183,8 +1181,7 @@ public:
    * @param dpt datapath instance
    * @param xid OpenFlow transaction identifier
    */
-  virtual void handle_get_config_reply_timeout(rofl::crofdpt &dpt,
-                                               uint32_t xid){};
+  void handle_get_config_reply_timeout(crofdpt &dpt, uint32_t xid) override{};
 
   /**
    * @brief	OpenFlow Stats-Reply message received.
@@ -1193,8 +1190,8 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_stats_reply(rofl::crofdpt &dpt, const rofl::cauxid &auxid,
-                                  rofl::openflow::cofmsg_stats_reply &msg){};
+  void handle_stats_reply(crofdpt &dpt, const cauxid &auxid,
+                          openflow::cofmsg_stats_reply &msg) override{};
 
   /**
    * @brief	Timer expired while waiting for OpenFlow Stats-Reply message.
@@ -1206,8 +1203,8 @@ public:
    * @param xid OpenFlow transaction identifier
    * @param stats_type statistics message subtype
    */
-  virtual void handle_stats_reply_timeout(rofl::crofdpt &dpt, uint32_t xid,
-                                          uint8_t stats_type){};
+  void handle_stats_reply_timeout(rofl::crofdpt &dpt, uint32_t xid,
+                                  uint8_t stats_type) override{};
 
   /**
    * @brief	OpenFlow Desc-Stats-Reply message received.
@@ -1216,9 +1213,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void
-  handle_desc_stats_reply(rofl::crofdpt &dpt, const rofl::cauxid &auxid,
-                          rofl::openflow::cofmsg_desc_stats_reply &msg){};
+  void
+  handle_desc_stats_reply(crofdpt &dpt, const cauxid &auxid,
+                          openflow::cofmsg_desc_stats_reply &msg) override{};
 
   /**
    * @brief	Timer expired while waiting for OpenFlow Desc-Stats-Reply
@@ -1230,8 +1227,7 @@ public:
    * @param dpt datapath instance
    * @param xid OpenFlow transaction identifier
    */
-  virtual void handle_desc_stats_reply_timeout(rofl::crofdpt &dpt,
-                                               uint32_t xid){};
+  void handle_desc_stats_reply_timeout(crofdpt &dpt, uint32_t xid) override{};
 
   /**
    * @brief	OpenFlow Table-Stats-Reply message received.
@@ -1240,9 +1236,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void
-  handle_table_stats_reply(rofl::crofdpt &dpt, const rofl::cauxid &auxid,
-                           rofl::openflow::cofmsg_table_stats_reply &msg){};
+  void handle_table_stats_reply(
+      rofl::crofdpt &dpt, const rofl::cauxid &auxid,
+      rofl::openflow::cofmsg_table_stats_reply &msg) override{};
 
   /**
    * @brief	Timer expired while waiting for OpenFlow Table-Stats-Reply
@@ -1254,8 +1250,8 @@ public:
    * @param dpt datapath instance
    * @param xid OpenFlow transaction identifier
    */
-  virtual void handle_table_stats_reply_timeout(rofl::crofdpt &dpt,
-                                                uint32_t xid){};
+  void handle_table_stats_reply_timeout(rofl::crofdpt &dpt,
+                                        uint32_t xid) override{};
 
   /**
    * @brief	OpenFlow Port-Stats-Reply message received.
@@ -1264,9 +1260,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void
-  handle_port_stats_reply(rofl::crofdpt &dpt, const rofl::cauxid &auxid,
-                          rofl::openflow::cofmsg_port_stats_reply &msg){};
+  void handle_port_stats_reply(
+      rofl::crofdpt &dpt, const rofl::cauxid &auxid,
+      rofl::openflow::cofmsg_port_stats_reply &msg) override{};
 
   /**
    * @brief	Timer expired while waiting for OpenFlow Port-Stats-Reply
@@ -1278,8 +1274,8 @@ public:
    * @param dpt datapath instance
    * @param xid OpenFlow transaction identifier
    */
-  virtual void handle_port_stats_reply_timeout(rofl::crofdpt &dpt,
-                                               uint32_t xid){};
+  void handle_port_stats_reply_timeout(rofl::crofdpt &dpt,
+                                       uint32_t xid) override{};
 
   /**
    * @brief	OpenFlow Flow-Stats-Reply message received.
@@ -1288,9 +1284,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void
-  handle_flow_stats_reply(rofl::crofdpt &dpt, const rofl::cauxid &auxid,
-                          rofl::openflow::cofmsg_flow_stats_reply &msg){};
+  void handle_flow_stats_reply(
+      rofl::crofdpt &dpt, const rofl::cauxid &auxid,
+      rofl::openflow::cofmsg_flow_stats_reply &msg) override{};
 
   /**
    * @brief	Timer expired while waiting for OpenFlow Flow-Stats-Reply
@@ -1302,8 +1298,8 @@ public:
    * @param dpt datapath instance
    * @param xid OpenFlow transaction identifier
    */
-  virtual void handle_flow_stats_reply_timeout(rofl::crofdpt &dpt,
-                                               uint32_t xid){};
+  void handle_flow_stats_reply_timeout(rofl::crofdpt &dpt,
+                                       uint32_t xid) override{};
 
   /**
    * @brief	OpenFlow Aggregate-Stats-Reply message received.
@@ -1312,9 +1308,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void
-  handle_aggregate_stats_reply(rofl::crofdpt &dpt, const rofl::cauxid &auxid,
-                               rofl::openflow::cofmsg_aggr_stats_reply &msg){};
+  void handle_aggregate_stats_reply(
+      rofl::crofdpt &dpt, const rofl::cauxid &auxid,
+      rofl::openflow::cofmsg_aggr_stats_reply &msg) override{};
 
   /**
    * @brief	Timer expired while waiting for OpenFlow Aggregate-Stats-Reply
@@ -1327,8 +1323,8 @@ public:
    * @param dpt datapath instance
    * @param xid OpenFlow transaction identifier
    */
-  virtual void handle_aggregate_stats_reply_timeout(rofl::crofdpt &dpt,
-                                                    uint32_t xid){};
+  void handle_aggregate_stats_reply_timeout(rofl::crofdpt &dpt,
+                                            uint32_t xid) override{};
 
   /**
    * @brief	OpenFlow Queue-Stats-Reply message received.
@@ -1337,9 +1333,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void
-  handle_queue_stats_reply(rofl::crofdpt &dpt, const rofl::cauxid &auxid,
-                           rofl::openflow::cofmsg_queue_stats_reply &msg){};
+  void handle_queue_stats_reply(
+      rofl::crofdpt &dpt, const rofl::cauxid &auxid,
+      rofl::openflow::cofmsg_queue_stats_reply &msg) override{};
 
   /**
    * @brief	Timer expired while waiting for OpenFlow Queue-Stats-Reply
@@ -1351,8 +1347,8 @@ public:
    * @param dpt datapath instance
    * @param xid OpenFlow transaction identifier
    */
-  virtual void handle_queue_stats_reply_timeout(rofl::crofdpt &dpt,
-                                                uint32_t xid){};
+  void handle_queue_stats_reply_timeout(rofl::crofdpt &dpt,
+                                        uint32_t xid) override{};
 
   /**
    * @brief	OpenFlow Group-Stats-Reply message received.
@@ -1361,9 +1357,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void
-  handle_group_stats_reply(rofl::crofdpt &dpt, const rofl::cauxid &auxid,
-                           rofl::openflow::cofmsg_group_stats_reply &msg){};
+  void handle_group_stats_reply(
+      rofl::crofdpt &dpt, const rofl::cauxid &auxid,
+      rofl::openflow::cofmsg_group_stats_reply &msg) override{};
 
   /**
    * @brief	Timer expired while waiting for OpenFlow Group-Stats-Reply
@@ -1375,8 +1371,8 @@ public:
    * @param dpt datapath instance
    * @param xid OpenFlow transaction identifier
    */
-  virtual void handle_group_stats_reply_timeout(rofl::crofdpt &dpt,
-                                                uint32_t xid){};
+  void handle_group_stats_reply_timeout(rofl::crofdpt &dpt,
+                                        uint32_t xid) override{};
 
   /**
    * @brief	OpenFlow Group-Desc-Stats-Reply message received.
@@ -1385,9 +1381,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_group_desc_stats_reply(
+  void handle_group_desc_stats_reply(
       rofl::crofdpt &dpt, const rofl::cauxid &auxid,
-      rofl::openflow::cofmsg_group_desc_stats_reply &msg){};
+      rofl::openflow::cofmsg_group_desc_stats_reply &msg) override{};
 
   /**
    * @brief	Timer expired while waiting for OpenFlow Group-Desc-Stats-Reply
@@ -1400,8 +1396,8 @@ public:
    * @param dpt datapath instance
    * @param xid OpenFlow transaction identifier
    */
-  virtual void handle_group_desc_stats_reply_timeout(rofl::crofdpt &dpt,
-                                                     uint32_t xid){};
+  void handle_group_desc_stats_reply_timeout(rofl::crofdpt &dpt,
+                                             uint32_t xid) override{};
 
   /**
    * @brief	OpenFlow Group-Features-Stats-Reply message received.
@@ -1410,9 +1406,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_group_features_stats_reply(
+  void handle_group_features_stats_reply(
       rofl::crofdpt &dpt, const rofl::cauxid &auxid,
-      rofl::openflow::cofmsg_group_features_stats_reply &msg){};
+      rofl::openflow::cofmsg_group_features_stats_reply &msg) override{};
 
   /**
    * @brief	Timer expired while waiting for OpenFlow
@@ -1425,8 +1421,8 @@ public:
    * @param dpt datapath instance
    * @param xid OpenFlow transaction identifier
    */
-  virtual void handle_group_features_stats_reply_timeout(rofl::crofdpt &dpt,
-                                                         uint32_t xid){};
+  void handle_group_features_stats_reply_timeout(rofl::crofdpt &dpt,
+                                                 uint32_t xid) override{};
 
   /**
    * @brief	OpenFlow Meter-Stats-Reply message received.
@@ -1435,9 +1431,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void
-  handle_meter_stats_reply(rofl::crofdpt &dpt, const rofl::cauxid &auxid,
-                           rofl::openflow::cofmsg_meter_stats_reply &msg){};
+  void handle_meter_stats_reply(
+      rofl::crofdpt &dpt, const rofl::cauxid &auxid,
+      rofl::openflow::cofmsg_meter_stats_reply &msg) override{};
 
   /**
    * @brief	Timer expired while waiting for OpenFlow Meter-Stats-Reply
@@ -1449,8 +1445,8 @@ public:
    * @param dpt datapath instance
    * @param xid OpenFlow transaction identifier
    */
-  virtual void handle_meter_stats_reply_timeout(rofl::crofdpt &dpt,
-                                                uint32_t xid){};
+  void handle_meter_stats_reply_timeout(rofl::crofdpt &dpt,
+                                        uint32_t xid) override{};
 
   /**
    * @brief	OpenFlow Meter-Config-Stats-Reply message received.
@@ -1459,9 +1455,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_meter_config_stats_reply(
+  void handle_meter_config_stats_reply(
       rofl::crofdpt &dpt, const rofl::cauxid &auxid,
-      rofl::openflow::cofmsg_meter_config_stats_reply &msg){};
+      rofl::openflow::cofmsg_meter_config_stats_reply &msg) override{};
 
   /**
    * @brief	Timer expired while waiting for OpenFlow
@@ -1475,8 +1471,8 @@ public:
    * @param dpt datapath instance
    * @param xid OpenFlow transaction identifier
    */
-  virtual void handle_meter_config_stats_reply_timeout(rofl::crofdpt &dpt,
-                                                       uint32_t xid){};
+  void handle_meter_config_stats_reply_timeout(rofl::crofdpt &dpt,
+                                               uint32_t xid) override{};
 
   /**
    * @brief	OpenFlow Meter-Features-Stats-Reply message received.
@@ -1485,9 +1481,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_meter_features_stats_reply(
+  void handle_meter_features_stats_reply(
       rofl::crofdpt &dpt, const rofl::cauxid &auxid,
-      rofl::openflow::cofmsg_meter_features_stats_reply &msg){};
+      rofl::openflow::cofmsg_meter_features_stats_reply &msg) override{};
 
   /**
    * @brief	Timer expired while waiting for OpenFlow
@@ -1500,8 +1496,8 @@ public:
    * @param dpt datapath instance
    * @param xid OpenFlow transaction identifier
    */
-  virtual void handle_meter_features_stats_reply_timeout(rofl::crofdpt &dpt,
-                                                         uint32_t xid){};
+  void handle_meter_features_stats_reply_timeout(rofl::crofdpt &dpt,
+                                                 uint32_t xid) override{};
 
   /**
    * @brief	OpenFlow Table-Features-Stats-Reply message received.
@@ -1510,9 +1506,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_table_features_stats_reply(
+  void handle_table_features_stats_reply(
       rofl::crofdpt &dpt, const rofl::cauxid &auxid,
-      rofl::openflow::cofmsg_table_features_stats_reply &msg){};
+      rofl::openflow::cofmsg_table_features_stats_reply &msg) override{};
 
   /**
    * @brief	Timer expired while waiting for OpenFlow
@@ -1525,8 +1521,8 @@ public:
    * @param dpt datapath instance
    * @param xid OpenFlow transaction identifier
    */
-  virtual void handle_table_features_stats_reply_timeout(rofl::crofdpt &dpt,
-                                                         uint32_t xid){};
+  void handle_table_features_stats_reply_timeout(rofl::crofdpt &dpt,
+                                                 uint32_t xid) override{};
 
   /**
    * @brief	OpenFlow Port-Desc-Stats-Reply message received.
@@ -1535,9 +1531,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_port_desc_stats_reply(
+  void handle_port_desc_stats_reply(
       rofl::crofdpt &dpt, const rofl::cauxid &auxid,
-      rofl::openflow::cofmsg_port_desc_stats_reply &msg){};
+      rofl::openflow::cofmsg_port_desc_stats_reply &msg) override{};
 
   /**
    * @brief	Timer expired while waiting for OpenFlow Port-Desc-Stats-Reply
@@ -1550,8 +1546,8 @@ public:
    * @param dpt datapath instance
    * @param xid OpenFlow transaction identifier
    */
-  virtual void handle_port_desc_stats_reply_timeout(rofl::crofdpt &dpt,
-                                                    uint32_t xid){};
+  void handle_port_desc_stats_reply_timeout(rofl::crofdpt &dpt,
+                                            uint32_t xid) override{};
 
   /**
    * @brief	OpenFlow Experimenter-Stats-Reply message received.
@@ -1560,9 +1556,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_experimenter_stats_reply(
+  void handle_experimenter_stats_reply(
       rofl::crofdpt &dpt, const rofl::cauxid &auxid,
-      rofl::openflow::cofmsg_experimenter_stats_reply &msg){};
+      rofl::openflow::cofmsg_experimenter_stats_reply &msg) override{};
 
   /**
    * @brief	Timer expired while waiting for OpenFlow
@@ -1576,8 +1572,8 @@ public:
    * @param dpt datapath instance
    * @param xid OpenFlow transaction identifier
    */
-  virtual void handle_experimenter_stats_reply_timeout(rofl::crofdpt &dpt,
-                                                       uint32_t xid){};
+  void handle_experimenter_stats_reply_timeout(rofl::crofdpt &dpt,
+                                               uint32_t xid) override{};
 
   /**
    * @brief	OpenFlow Packet-In message received.
@@ -1586,8 +1582,8 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_packet_in(rofl::crofdpt &dpt, const rofl::cauxid &auxid,
-                                rofl::openflow::cofmsg_packet_in &msg){};
+  void handle_packet_in(rofl::crofdpt &dpt, const rofl::cauxid &auxid,
+                        rofl::openflow::cofmsg_packet_in &msg) override{};
 
   /**
    * @brief	OpenFlow Barrier-Reply message received.
@@ -1596,9 +1592,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void
+  void
   handle_barrier_reply(rofl::crofdpt &dpt, const rofl::cauxid &auxid,
-                       rofl::openflow::cofmsg_barrier_reply &msg){};
+                       rofl::openflow::cofmsg_barrier_reply &msg) override{};
 
   /**
    * @brief	Timer expired while waiting for OpenFlow Barrier-Reply message.
@@ -1609,7 +1605,8 @@ public:
    * @param dpt datapath instance
    * @param xid OpenFlow transaction identifier
    */
-  virtual void handle_barrier_reply_timeout(rofl::crofdpt &dpt, uint32_t xid){};
+  void handle_barrier_reply_timeout(rofl::crofdpt &dpt,
+                                    uint32_t xid) override{};
 
   /**
    * @brief	OpenFlow Flow-Removed message received.
@@ -1618,9 +1615,8 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_flow_removed(rofl::crofdpt &dpt,
-                                   const rofl::cauxid &auxid,
-                                   rofl::openflow::cofmsg_flow_removed &msg){};
+  void handle_flow_removed(rofl::crofdpt &dpt, const rofl::cauxid &auxid,
+                           rofl::openflow::cofmsg_flow_removed &msg) override{};
 
   /**
    * @brief	OpenFlow Port-Status-Reply message received.
@@ -1629,8 +1625,8 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_port_status(rofl::crofdpt &dpt, const rofl::cauxid &auxid,
-                                  rofl::openflow::cofmsg_port_status &msg){};
+  void handle_port_status(rofl::crofdpt &dpt, const rofl::cauxid &auxid,
+                          rofl::openflow::cofmsg_port_status &msg) override{};
 
   /**
    * @brief	OpenFlow Queue-Get-Config-Reply message received.
@@ -1639,9 +1635,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_queue_get_config_reply(
+  void handle_queue_get_config_reply(
       rofl::crofdpt &dpt, const rofl::cauxid &auxid,
-      rofl::openflow::cofmsg_queue_get_config_reply &msg){};
+      rofl::openflow::cofmsg_queue_get_config_reply &msg) override{};
 
   /**
    * @brief	Timer expired while waiting for OpenFlow Table-Stats-Reply
@@ -1653,8 +1649,8 @@ public:
    * @param dpt datapath instance
    * @param xid OpenFlow transaction identifier
    */
-  virtual void handle_queue_get_config_reply_timeout(rofl::crofdpt &dpt,
-                                                     uint32_t xid){};
+  void handle_queue_get_config_reply_timeout(rofl::crofdpt &dpt,
+                                             uint32_t xid) override{};
 
   /**
    * @brief	OpenFlow Error message received.
@@ -1663,9 +1659,8 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_error_message(rofl::crofdpt &dpt,
-                                    const rofl::cauxid &auxid,
-                                    rofl::openflow::cofmsg_error &msg){};
+  void handle_error_message(rofl::crofdpt &dpt, const rofl::cauxid &auxid,
+                            rofl::openflow::cofmsg_error &msg) override{};
 
   /**
    * @brief	OpenFlow Experimenter message received.
@@ -1674,9 +1669,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void
-  handle_experimenter_message(rofl::crofdpt &dpt, const rofl::cauxid &auxid,
-                              rofl::openflow::cofmsg_experimenter &msg){};
+  void handle_experimenter_message(
+      rofl::crofdpt &dpt, const rofl::cauxid &auxid,
+      rofl::openflow::cofmsg_experimenter &msg) override{};
 
   /**
    * @brief	Timer expired while waiting for OpenFlow Experimenter message.
@@ -1687,7 +1682,7 @@ public:
    * @param dpt datapath instance
    * @param xid OpenFlow transaction identifier
    */
-  virtual void handle_experimenter_timeout(rofl::crofdpt &dpt, uint32_t xid){};
+  void handle_experimenter_timeout(rofl::crofdpt &dpt, uint32_t xid) override{};
 
   /**
    * @brief	OpenFlow Role-Reply message received.
@@ -1696,8 +1691,8 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_role_reply(rofl::crofdpt &dpt, const rofl::cauxid &auxid,
-                                 rofl::openflow::cofmsg_role_reply &msg){};
+  void handle_role_reply(rofl::crofdpt &dpt, const rofl::cauxid &auxid,
+                         rofl::openflow::cofmsg_role_reply &msg) override{};
 
   /**
    * @brief	Timer expired while waiting for OpenFlow Role-Reply message.
@@ -1708,7 +1703,7 @@ public:
    * @param dpt datapath instance
    * @param xid OpenFlow transaction identifier
    */
-  virtual void handle_role_reply_timeout(rofl::crofdpt &dpt, uint32_t xid){};
+  void handle_role_reply_timeout(rofl::crofdpt &dpt, uint32_t xid) override{};
 
   /**
    * @brief	OpenFlow Get-Async-Config-Reply message received.
@@ -1717,9 +1712,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_get_async_config_reply(
+  void handle_get_async_config_reply(
       rofl::crofdpt &dpt, const rofl::cauxid &auxid,
-      rofl::openflow::cofmsg_get_async_config_reply &msg){};
+      rofl::openflow::cofmsg_get_async_config_reply &msg) override{};
 
   /**
    * @brief	Timer expired while waiting for OpenFlow Get-Async-Config-Reply
@@ -1732,8 +1727,8 @@ public:
    * @param dpt datapath instance
    * @param xid OpenFlow transaction identifier
    */
-  virtual void handle_get_async_config_reply_timeout(rofl::crofdpt &dpt,
-                                                     uint32_t xid){};
+  void handle_get_async_config_reply_timeout(rofl::crofdpt &dpt,
+                                             uint32_t xid) override{};
 
   /**@}*/
 
@@ -1773,9 +1768,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void
-  handle_features_request(rofl::crofctl &ctl, const rofl::cauxid &auxid,
-                          rofl::openflow::cofmsg_features_request &msg){};
+  void handle_features_request(
+      rofl::crofctl &ctl, const rofl::cauxid &auxid,
+      rofl::openflow::cofmsg_features_request &msg) override{};
 
   /**
    * @brief	OpenFlow Get-Config-Request message received.
@@ -1784,9 +1779,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void
-  handle_get_config_request(rofl::crofctl &ctl, const rofl::cauxid &auxid,
-                            rofl::openflow::cofmsg_get_config_request &msg){};
+  void handle_get_config_request(
+      rofl::crofctl &ctl, const rofl::cauxid &auxid,
+      rofl::openflow::cofmsg_get_config_request &msg) override{};
 
   /**
    * @brief	OpenFlow Stats-Request message received.
@@ -1795,9 +1790,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void
+  void
   handle_stats_request(rofl::crofctl &ctl, const rofl::cauxid &auxid,
-                       rofl::openflow::cofmsg_stats_request &msg){};
+                       rofl::openflow::cofmsg_stats_request &msg) override{};
 
   /**
    * @brief	OpenFlow Desc-Stats-Request message received.
@@ -1806,9 +1801,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void
-  handle_desc_stats_request(rofl::crofctl &ctl, const rofl::cauxid &auxid,
-                            rofl::openflow::cofmsg_desc_stats_request &msg){};
+  void handle_desc_stats_request(
+      rofl::crofctl &ctl, const rofl::cauxid &auxid,
+      rofl::openflow::cofmsg_desc_stats_request &msg) override{};
 
   /**
    * @brief	OpenFlow Table-Stats-Request message received.
@@ -1817,9 +1812,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void
-  handle_table_stats_request(rofl::crofctl &ctl, const rofl::cauxid &auxid,
-                             rofl::openflow::cofmsg_table_stats_request &msg){};
+  void handle_table_stats_request(
+      rofl::crofctl &ctl, const rofl::cauxid &auxid,
+      rofl::openflow::cofmsg_table_stats_request &msg) override{};
 
   /**
    * @brief	OpenFlow Port-Stats-Request message received.
@@ -1828,9 +1823,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void
-  handle_port_stats_request(rofl::crofctl &ctl, const rofl::cauxid &auxid,
-                            rofl::openflow::cofmsg_port_stats_request &msg){};
+  void handle_port_stats_request(
+      rofl::crofctl &ctl, const rofl::cauxid &auxid,
+      rofl::openflow::cofmsg_port_stats_request &msg) override{};
 
   /**
    * @brief	OpenFlow Flow-Stats-Request message received.
@@ -1839,9 +1834,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void
-  handle_flow_stats_request(rofl::crofctl &ctl, const rofl::cauxid &auxid,
-                            rofl::openflow::cofmsg_flow_stats_request &msg){};
+  void handle_flow_stats_request(
+      rofl::crofctl &ctl, const rofl::cauxid &auxid,
+      rofl::openflow::cofmsg_flow_stats_request &msg) override{};
 
   /**
    * @brief	OpenFlow Aggregate-Stats-Request message received.
@@ -1850,9 +1845,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_aggregate_stats_request(
+  void handle_aggregate_stats_request(
       rofl::crofctl &ctl, const rofl::cauxid &auxid,
-      rofl::openflow::cofmsg_aggr_stats_request &msg){};
+      rofl::openflow::cofmsg_aggr_stats_request &msg) override{};
 
   /**
    * @brief	OpenFlow Queue-Stats-Request message received.
@@ -1861,9 +1856,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void
-  handle_queue_stats_request(rofl::crofctl &ctl, const rofl::cauxid &auxid,
-                             rofl::openflow::cofmsg_queue_stats_request &msg){};
+  void handle_queue_stats_request(
+      rofl::crofctl &ctl, const rofl::cauxid &auxid,
+      rofl::openflow::cofmsg_queue_stats_request &msg) override{};
 
   /**
    * @brief	OpenFlow Group-Stats-Request message received.
@@ -1872,9 +1867,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void
-  handle_group_stats_request(rofl::crofctl &ctl, const rofl::cauxid &auxid,
-                             rofl::openflow::cofmsg_group_stats_request &msg){};
+  void handle_group_stats_request(
+      rofl::crofctl &ctl, const rofl::cauxid &auxid,
+      rofl::openflow::cofmsg_group_stats_request &msg) override{};
 
   /**
    * @brief	OpenFlow Group-Desc-Stats-Request message received.
@@ -1883,9 +1878,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_group_desc_stats_request(
+  void handle_group_desc_stats_request(
       rofl::crofctl &ctl, const rofl::cauxid &auxid,
-      rofl::openflow::cofmsg_group_desc_stats_request &msg){};
+      rofl::openflow::cofmsg_group_desc_stats_request &msg) override{};
 
   /**
    * @brief	OpenFlow Group-Features-Stats-Request message received.
@@ -1894,9 +1889,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_group_features_stats_request(
+  void handle_group_features_stats_request(
       rofl::crofctl &ctl, const rofl::cauxid &auxid,
-      rofl::openflow::cofmsg_group_features_stats_request &msg){};
+      rofl::openflow::cofmsg_group_features_stats_request &msg) override{};
 
   /**
    * @brief	OpenFlow Meter-Stats-Request message received.
@@ -1905,9 +1900,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void
-  handle_meter_stats_request(rofl::crofctl &ctl, const rofl::cauxid &auxid,
-                             rofl::openflow::cofmsg_meter_stats_request &msg){};
+  void handle_meter_stats_request(
+      rofl::crofctl &ctl, const rofl::cauxid &auxid,
+      rofl::openflow::cofmsg_meter_stats_request &msg) override{};
 
   /**
    * @brief	OpenFlow Meter-Config-Stats-Request message received.
@@ -1916,9 +1911,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_meter_config_stats_request(
+  void handle_meter_config_stats_request(
       rofl::crofctl &ctl, const rofl::cauxid &auxid,
-      rofl::openflow::cofmsg_meter_config_stats_request &msg){};
+      rofl::openflow::cofmsg_meter_config_stats_request &msg) override{};
 
   /**
    * @brief	OpenFlow Meter-Features-Stats-Request message received.
@@ -1927,9 +1922,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_meter_features_stats_request(
+  void handle_meter_features_stats_request(
       rofl::crofctl &ctl, const rofl::cauxid &auxid,
-      rofl::openflow::cofmsg_meter_features_stats_request &msg){};
+      rofl::openflow::cofmsg_meter_features_stats_request &msg) override{};
 
   /**
    * @brief	OpenFlow Table-Features-Stats-Request message received.
@@ -1938,9 +1933,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_table_features_stats_request(
+  void handle_table_features_stats_request(
       rofl::crofctl &ctl, const rofl::cauxid &auxid,
-      rofl::openflow::cofmsg_table_features_stats_request &msg){};
+      rofl::openflow::cofmsg_table_features_stats_request &msg) override{};
 
   /**
    * @brief	OpenFlow Port-Desc-Stats-Request message received.
@@ -1949,9 +1944,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_port_desc_stats_request(
+  void handle_port_desc_stats_request(
       rofl::crofctl &ctl, const rofl::cauxid &auxid,
-      rofl::openflow::cofmsg_port_desc_stats_request &msg){};
+      rofl::openflow::cofmsg_port_desc_stats_request &msg) override{};
 
   /**
    * @brief	OpenFlow Experimenter-Stats-Request message received.
@@ -1960,9 +1955,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_experimenter_stats_request(
+  void handle_experimenter_stats_request(
       rofl::crofctl &ctl, const rofl::cauxid &auxid,
-      rofl::openflow::cofmsg_experimenter_stats_request &msg){};
+      rofl::openflow::cofmsg_experimenter_stats_request &msg) override{};
 
   /**
    * @brief	OpenFlow Packet-Out message received.
@@ -1971,8 +1966,8 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_packet_out(rofl::crofctl &ctl, const rofl::cauxid &auxid,
-                                 rofl::openflow::cofmsg_packet_out &msg){};
+  void handle_packet_out(rofl::crofctl &ctl, const rofl::cauxid &auxid,
+                         rofl::openflow::cofmsg_packet_out &msg) override{};
 
   /**
    * @brief	OpenFlow Barrier-Request message received.
@@ -1981,9 +1976,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void
-  handle_barrier_request(rofl::crofctl &ctl, const rofl::cauxid &auxid,
-                         rofl::openflow::cofmsg_barrier_request &msg){};
+  void handle_barrier_request(
+      rofl::crofctl &ctl, const rofl::cauxid &auxid,
+      rofl::openflow::cofmsg_barrier_request &msg) override{};
 
   /**
    * @brief	OpenFlow Flow-Mod message received.
@@ -1992,8 +1987,8 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_flow_mod(rofl::crofctl &ctl, const rofl::cauxid &auxid,
-                               rofl::openflow::cofmsg_flow_mod &msg){};
+  void handle_flow_mod(rofl::crofctl &ctl, const rofl::cauxid &auxid,
+                       rofl::openflow::cofmsg_flow_mod &msg) override{};
 
   /**
    * @brief	OpenFlow Group-Mod message received.
@@ -2002,8 +1997,8 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_group_mod(rofl::crofctl &ctl, const rofl::cauxid &auxid,
-                                rofl::openflow::cofmsg_group_mod &msg){};
+  void handle_group_mod(rofl::crofctl &ctl, const rofl::cauxid &auxid,
+                        rofl::openflow::cofmsg_group_mod &msg) override{};
 
   /**
    * @brief	OpenFlow Table-Mod message received.
@@ -2012,8 +2007,8 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_table_mod(rofl::crofctl &ctl, const rofl::cauxid &auxid,
-                                rofl::openflow::cofmsg_table_mod &msg){};
+  void handle_table_mod(rofl::crofctl &ctl, const rofl::cauxid &auxid,
+                        rofl::openflow::cofmsg_table_mod &msg) override{};
 
   /**
    * @brief	OpenFlow Port-Mod message received.
@@ -2022,8 +2017,8 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_port_mod(rofl::crofctl &ctl, const rofl::cauxid &auxid,
-                               rofl::openflow::cofmsg_port_mod &msg){};
+  void handle_port_mod(rofl::crofctl &ctl, const rofl::cauxid &auxid,
+                       rofl::openflow::cofmsg_port_mod &msg) override{};
 
   /**
    * @brief	OpenFlow Queue-Get-Config-Request message received.
@@ -2032,9 +2027,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_queue_get_config_request(
+  void handle_queue_get_config_request(
       rofl::crofctl &ctl, const rofl::cauxid &auxid,
-      rofl::openflow::cofmsg_queue_get_config_request &msg){};
+      rofl::openflow::cofmsg_queue_get_config_request &msg) override{};
 
   /**
    * @brief	OpenFlow Set-Config message received.
@@ -2043,8 +2038,8 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_set_config(rofl::crofctl &ctl, const rofl::cauxid &auxid,
-                                 rofl::openflow::cofmsg_set_config &msg){};
+  void handle_set_config(rofl::crofctl &ctl, const rofl::cauxid &auxid,
+                         rofl::openflow::cofmsg_set_config &msg) override{};
 
   /**
    * @brief	OpenFlow Experimenter message received.
@@ -2053,9 +2048,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void
-  handle_experimenter_message(rofl::crofctl &ctl, const rofl::cauxid &auxid,
-                              rofl::openflow::cofmsg_experimenter &msg){};
+  void handle_experimenter_message(
+      rofl::crofctl &ctl, const rofl::cauxid &auxid,
+      rofl::openflow::cofmsg_experimenter &msg) override{};
 
   /**
    * @brief	Timer expired while waiting for OpenFlow Experimenter message.
@@ -2066,7 +2061,7 @@ public:
    * @param ctl controller instance
    * @param xid OpenFlow transaction identifier
    */
-  virtual void handle_experimenter_timeout(rofl::crofctl &ctl, uint32_t xid){};
+  void handle_experimenter_timeout(rofl::crofctl &ctl, uint32_t xid) override{};
 
   /**
    * @brief	OpenFlow error message received.
@@ -2075,9 +2070,8 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_error_message(rofl::crofctl &ctl,
-                                    const rofl::cauxid &auxid,
-                                    rofl::openflow::cofmsg_error &msg){};
+  void handle_error_message(rofl::crofctl &ctl, const rofl::cauxid &auxid,
+                            rofl::openflow::cofmsg_error &msg) override{};
 
   /**
    * @brief	OpenFlow Role-Request message received.
@@ -2086,9 +2080,8 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_role_request(rofl::crofctl &ctl,
-                                   const rofl::cauxid &auxid,
-                                   rofl::openflow::cofmsg_role_request &msg){};
+  void handle_role_request(rofl::crofctl &ctl, const rofl::cauxid &auxid,
+                           rofl::openflow::cofmsg_role_request &msg) override{};
 
   /**
    * @brief	OpenFlow Get-Async-Config-Request message received.
@@ -2097,9 +2090,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_get_async_config_request(
+  void handle_get_async_config_request(
       rofl::crofctl &ctl, const rofl::cauxid &auxid,
-      rofl::openflow::cofmsg_get_async_config_request &msg){};
+      rofl::openflow::cofmsg_get_async_config_request &msg) override{};
 
   /**
    * @brief	OpenFlow Set-Async-Config message received.
@@ -2108,9 +2101,9 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void
-  handle_set_async_config(rofl::crofctl &ctl, const rofl::cauxid &auxid,
-                          rofl::openflow::cofmsg_set_async_config &msg){};
+  void handle_set_async_config(
+      rofl::crofctl &ctl, const rofl::cauxid &auxid,
+      rofl::openflow::cofmsg_set_async_config &msg) override{};
 
   /**
    * @brief	OpenFlow Meter-Mod message received.
@@ -2119,8 +2112,8 @@ public:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  virtual void handle_meter_mod(rofl::crofctl &ctl, const rofl::cauxid &auxid,
-                                rofl::openflow::cofmsg_meter_mod &msg){};
+  void handle_meter_mod(rofl::crofctl &ctl, const rofl::cauxid &auxid,
+                        rofl::openflow::cofmsg_meter_mod &msg) override{};
 
   /**@}*/
 
@@ -2154,82 +2147,79 @@ private:
   static void terminate();
 
 protected:
-  virtual void handle_wakeup(cthread &thread);
+  void handle_timeout(void *userdata) override;
 
-  virtual void handle_timeout(cthread &thread, uint32_t timer_id);
-
-  virtual void handle_read_event(cthread &thread, int fd);
-
-  virtual void handle_write_event(cthread &thread, int fd){/* not in use */};
+  void handle_read(int fd, void *userdata) override;
 
 private:
-  virtual void handle_established(crofdpt &dpt, uint8_t ofp_version);
+  void handle_established(crofdpt &dpt, uint8_t ofp_version) override;
 
-  virtual void handle_closed(crofdpt &dpt);
+  void handle_closed(crofdpt &dpt) override;
 
-  virtual void handle_established(crofdpt &dpt, crofconn &conn,
-                                  uint8_t ofp_version);
+  void handle_established(crofdpt &dpt, crofconn &conn,
+                          uint8_t ofp_version) override;
 
-  virtual void handle_closed(crofdpt &dpt, crofconn &conn);
+  void handle_closed(crofdpt &dpt, crofconn &conn) override;
 
-  virtual void handle_connect_refused(crofdpt &dpt, crofconn &conn);
+  void handle_connect_refused(crofdpt &dpt, crofconn &conn) override;
 
-  virtual void handle_connect_failed(crofdpt &dpt, crofconn &conn);
+  void handle_connect_failed(crofdpt &dpt, crofconn &conn) override;
 
-  virtual void handle_accept_failed(crofdpt &dpt, crofconn &conn);
+  void handle_accept_failed(crofdpt &dpt, crofconn &conn) override;
 
-  virtual void handle_negotiation_failed(crofdpt &dpt, crofconn &conn);
+  void handle_negotiation_failed(crofdpt &dpt, crofconn &conn) override;
 
-  virtual void congestion_occurred_indication(crofdpt &dpt, crofconn &conn);
+  void congestion_occurred_indication(crofdpt &dpt, crofconn &conn) override;
 
-  virtual void congestion_solved_indication(crofdpt &dpt, crofconn &conn);
-
-private:
-  virtual void handle_established(crofctl &ctl, uint8_t ofp_version);
-
-  virtual void handle_closed(crofctl &ctl);
-
-  virtual void handle_established(crofctl &ctl, crofconn &conn,
-                                  uint8_t ofp_version);
-
-  virtual void handle_closed(crofctl &ctl, crofconn &conn);
-
-  virtual void handle_connect_refused(crofctl &ctl, crofconn &conn);
-
-  virtual void handle_connect_failed(crofctl &ctl, crofconn &conn);
-
-  virtual void handle_accept_failed(crofctl &ctl, crofconn &conn);
-
-  virtual void handle_negotiation_failed(crofctl &ctl, crofconn &conn);
-
-  virtual void congestion_occurred_indication(crofctl &ctl, crofconn &conn);
-
-  virtual void congestion_solved_indication(crofctl &ctl, crofconn &conn);
+  void congestion_solved_indication(crofdpt &dpt, crofconn &conn) override;
 
 private:
-  virtual void handle_established(crofconn &conn, uint8_t ofp_version);
+  void handle_established(crofctl &ctl, uint8_t ofp_version) override;
 
-  virtual void handle_connect_refused(crofconn &conn){/* not used */};
+  void handle_closed(crofctl &ctl) override;
 
-  virtual void handle_connect_failed(crofconn &conn){/* not used */};
+  void handle_established(crofctl &ctl, crofconn &conn,
+                          uint8_t ofp_version) override;
 
-  virtual void handle_accept_failed(crofconn &conn);
+  void handle_closed(crofctl &ctl, crofconn &conn) override;
 
-  virtual void handle_negotiation_failed(crofconn &conn);
+  void handle_connect_refused(crofctl &ctl, crofconn &conn) override;
 
-  virtual void handle_closed(crofconn &conn);
+  void handle_connect_failed(crofctl &ctl, crofconn &conn) override;
 
-  virtual void handle_recv(crofconn &conn, rofl::openflow::cofmsg *msg) {
+  void handle_accept_failed(crofctl &ctl, crofconn &conn) override;
+
+  void handle_negotiation_failed(crofctl &ctl, crofconn &conn) override;
+
+  void congestion_occurred_indication(crofctl &ctl, crofconn &conn) override;
+
+  void congestion_solved_indication(crofctl &ctl, crofconn &conn) override;
+
+private:
+  void handle_established(crofconn &conn, uint8_t ofp_version) override;
+
+  void handle_connect_refused(crofconn &conn) override { /* not used */
+  }
+
+  void handle_connect_failed(crofconn &conn) override { /* not used */
+  }
+
+  void handle_accept_failed(crofconn &conn) override;
+
+  void handle_negotiation_failed(crofconn &conn) override;
+
+  void handle_closed(crofconn &conn) override;
+
+  void handle_recv(crofconn &conn, rofl::openflow::cofmsg *msg) override {
     delete msg;
   };
 
-  virtual void congestion_occurred_indication(crofconn &conn){};
+  void congestion_occurred_indication(crofconn &conn) override{};
 
-  virtual void congestion_solved_indication(crofconn &conn){};
+  void congestion_solved_indication(crofconn &conn) override{};
 
-  virtual void handle_transaction_timeout(crofconn &conn, uint32_t xid,
-                                          uint8_t type,
-                                          uint16_t sub_type = 0){};
+  void handle_transaction_timeout(crofconn &conn, uint32_t xid, uint8_t type,
+                                  uint16_t sub_type = 0) override{};
 
 private:
   /**

--- a/src/rofl/common/crofchan.h
+++ b/src/rofl/common/crofchan.h
@@ -139,6 +139,8 @@ public:
    *
    */
   virtual ~crofchan() {
+    /* drop all timers */
+    thread->drop_timer(this, cthread::ALL_TIMERS);
     /* drop connections scheduled for removal */
     __drop_conns_deletion();
     /* drop active connections */

--- a/src/rofl/common/crofconn.cc
+++ b/src/rofl/common/crofconn.cc
@@ -1222,7 +1222,7 @@ void crofconn::handle_rx_messages() {
             return;
           }
 
-          if ((msg = rxqueues[queue_id].retrieve()) == NULL) {
+          if ((msg = rxqueues[queue_id].retrieve()) == nullptr) {
             break; // no further messages in this queue
           }
 
@@ -1298,7 +1298,7 @@ void crofconn::handle_rx_multipart_message(rofl::openflow::cofmsg *msg) {
     rofl::openflow::cofmsg_stats_request *stats =
         dynamic_cast<rofl::openflow::cofmsg_stats_request *>(msg);
 
-    if (NULL == stats) {
+    if (nullptr == stats) {
       VLOG(1) << __FUNCTION__
               << " dropping multipart request, invalid message type";
       delete msg;
@@ -1345,7 +1345,7 @@ void crofconn::handle_rx_multipart_message(rofl::openflow::cofmsg *msg) {
     rofl::openflow::cofmsg_stats_reply *stats =
         dynamic_cast<rofl::openflow::cofmsg_stats_reply *>(msg);
 
-    if (NULL == stats) {
+    if (nullptr == stats) {
       VLOG(1) << __FUNCTION__
               << " dropping multipart reply, invalid message type";
       delete msg;

--- a/src/rofl/common/crofconn.cc
+++ b/src/rofl/common/crofconn.cc
@@ -30,6 +30,7 @@ using namespace rofl;
 crofconn::~crofconn() {
   set_state(STATE_CLOSING);
   thread->remove_wakeup_observer(this, wake_handle);
+  thread->drop_timer(this, cthread::ALL_TIMERS);
 }
 
 crofconn::crofconn(cthread *thread, crofconn_env *env)

--- a/src/rofl/common/crofconn.cc
+++ b/src/rofl/common/crofconn.cc
@@ -19,7 +19,7 @@ using namespace rofl;
 /*static*/ crwlock crofconn_env::connection_envs_lock;
 /*static*/ const int crofconn::RXQUEUE_MAX_SIZE_DEFAULT = 128;
 /*static*/ const unsigned int crofconn::DEFAULT_SEGMENTATION_THRESHOLD = 65535;
-/*static*/ const time_t crofconn::DEFAULT_HELLO_TIMEOUT = 3;
+/*static*/ const time_t crofconn::DEFAULT_HELLO_TIMEOUT = 30;
 /*static*/ const time_t crofconn::DEFAULT_FEATURES_TIMEOUT = 5;
 /*static*/ const time_t crofconn::DEFAULT_ECHO_TIMEOUT = 3;
 /*static*/ const time_t crofconn::DEFAULT_LIFECHECK_TIMEOUT = 1;
@@ -29,11 +29,11 @@ using namespace rofl;
 crofconn::~crofconn() {
   /* stop worker thread */
   set_state(STATE_CLOSING);
-  thread.stop();
+  thread->remove_wakeup_observer(this, wake_handle);
 }
 
-crofconn::crofconn(crofconn_env *env)
-    : env(env), thread(this), rofsock(this), dpid(0), auxid(0),
+crofconn::crofconn(cthread *thread, crofconn_env *env)
+    : env(env), thread(thread), rofsock(thread, this), dpid(0), auxid(0),
       ofp_version(rofl::openflow::OFP_VERSION_UNKNOWN), mode(MODE_UNKNOWN),
       state(STATE_DISCONNECTED), flag_hello_sent(false), flag_hello_rcvd(false),
       rxweights(QUEUE_MAX), rxqueues(QUEUE_MAX), rx_thread_working(false),
@@ -58,7 +58,7 @@ crofconn::crofconn(crofconn_env *env)
     rxqueues[queue_id].set_queue_max_size(rxqueue_max_size);
   }
   /* start worker thread */
-  thread.start("crofconn");
+  thread->add_wakeup_observer(this, &wake_handle);
 }
 
 void crofconn::close() { set_state(STATE_CLOSING); };
@@ -100,7 +100,8 @@ void crofconn::tls_connect(
   rofsock.tls_connect(reconnect);
 };
 
-void crofconn::handle_timeout(cthread &thread, uint32_t timer_id) {
+void crofconn::handle_timeout(void *userdata) {
+  int timer_id = (long)userdata;
   switch (timer_id) {
   case TIMER_ID_NEED_LIFE_CHECK: {
     send_echo_request();
@@ -153,7 +154,7 @@ void crofconn::set_state(enum crofconn_state_t new_state) {
               << " raddr=" << rofsock.get_raddr().str();
 
       /* stop periodic checks for connection state (OAM) */
-      thread.drop_timer(TIMER_ID_NEED_LIFE_CHECK);
+      thread->drop_timer(this, TIMER_ID_NEED_LIFE_CHECK);
 
       clear_pending_requests();
       clear_pending_segments();
@@ -194,8 +195,8 @@ void crofconn::set_state(enum crofconn_state_t new_state) {
               << " laddr=" << rofsock.get_laddr().str()
               << " raddr=" << rofsock.get_raddr().str();
       if (not flag_hello_rcvd) {
-        thread.add_timer(TIMER_ID_WAIT_FOR_HELLO,
-                         ctimespec().expire_in(timeout_hello));
+        thread->add_timer(this, TIMER_ID_WAIT_FOR_HELLO,
+                          ctimespec().expire_in(timeout_hello));
       }
       if (not flag_hello_sent) {
         send_hello_message();
@@ -207,7 +208,7 @@ void crofconn::set_state(enum crofconn_state_t new_state) {
               << versionbitmap_peer.str()
               << " laddr=" << rofsock.get_laddr().str()
               << " raddr=" << rofsock.get_raddr().str();
-      thread.drop_timer(TIMER_ID_WAIT_FOR_HELLO);
+      thread->drop_timer(this, TIMER_ID_WAIT_FOR_HELLO);
       send_features_request();
 
     } break;
@@ -216,10 +217,10 @@ void crofconn::set_state(enum crofconn_state_t new_state) {
               << static_cast<unsigned>(ofp_version.load())
               << " laddr=" << rofsock.get_laddr().str()
               << " raddr=" << rofsock.get_raddr().str();
-      thread.drop_timer(TIMER_ID_WAIT_FOR_HELLO);
+      thread->drop_timer(this, TIMER_ID_WAIT_FOR_HELLO);
       /* start periodic checks for connection state (OAM) */
-      thread.add_timer(TIMER_ID_NEED_LIFE_CHECK,
-                       ctimespec().expire_in(timeout_lifecheck));
+      thread->add_timer(this, TIMER_ID_NEED_LIFE_CHECK,
+                        ctimespec().expire_in(timeout_lifecheck));
       crofconn_env::call_env(env).handle_established(*this, ofp_version);
 
     } break;
@@ -241,7 +242,7 @@ void crofconn::error_rcvd(rofl::openflow::cofmsg *pmsg) {
     return;
   }
 
-  thread.drop_timer(TIMER_ID_WAIT_FOR_HELLO);
+  thread->drop_timer(this, TIMER_ID_WAIT_FOR_HELLO);
 
   try {
 
@@ -329,7 +330,9 @@ void crofconn::send_hello_message() {
             << " laddr=" << rofsock.get_laddr().str()
             << " raddr=" << rofsock.get_raddr().str();
 
-    rofsock.send_message(msg);
+    int rv = rofsock.send_message(
+        msg, true); // XXX(toanju): this might fail silently...
+    VLOG(2) << __FUNCTION__ << ": send_message returned rv=" << rv;
 
   } catch (rofl::exception &e) {
     VLOG(1) << __FUNCTION__ << " error: " << e.what();
@@ -354,7 +357,7 @@ void crofconn::hello_rcvd(rofl::openflow::cofmsg *pmsg) {
 
   flag_hello_rcvd = true;
 
-  thread.drop_timer(TIMER_ID_WAIT_FOR_HELLO);
+  thread->drop_timer(this, TIMER_ID_WAIT_FOR_HELLO);
 
   try {
 
@@ -506,7 +509,7 @@ void crofconn::hello_expired() {
           << " laddr=" << rofsock.get_laddr().str()
           << " raddr=" << rofsock.get_raddr().str();
 
-  switch (state) {
+  switch (state.load()) {
   case STATE_ESTABLISHED: {
     /* ignore event */
     VLOG(1) << __FUNCTION__
@@ -530,8 +533,8 @@ void crofconn::hello_expired() {
 
 void crofconn::send_features_request() {
   try {
-    thread.add_timer(TIMER_ID_WAIT_FOR_FEATURES,
-                     ctimespec().expire_in(timeout_features));
+    thread->add_timer(this, TIMER_ID_WAIT_FOR_FEATURES,
+                      ctimespec().expire_in(timeout_features));
 
     rofl::openflow::cofmsg_features_request *msg =
         new rofl::openflow::cofmsg_features_request(
@@ -562,7 +565,7 @@ void crofconn::features_reply_rcvd(rofl::openflow::cofmsg *pmsg) {
     return;
   }
 
-  thread.drop_timer(TIMER_ID_WAIT_FOR_FEATURES);
+  thread->drop_timer(this, TIMER_ID_WAIT_FOR_FEATURES);
 
   try {
     set_dpid(msg->get_dpid());
@@ -594,8 +597,8 @@ void crofconn::features_request_expired() {
 
 void crofconn::send_echo_request() {
   try {
-    thread.add_timer(TIMER_ID_WAIT_FOR_ECHO,
-                     ctimespec().expire_in(timeout_echo));
+    thread->add_timer(this, TIMER_ID_WAIT_FOR_ECHO,
+                      ctimespec().expire_in(timeout_echo));
 
     rofl::openflow::cofmsg_echo_request *msg =
         new rofl::openflow::cofmsg_echo_request(ofp_version,
@@ -620,13 +623,13 @@ void crofconn::echo_reply_rcvd(rofl::openflow::cofmsg *pmsg) {
 
   assert(nullptr != msg);
 
-  thread.drop_timer(TIMER_ID_WAIT_FOR_ECHO);
+  thread->drop_timer(this, TIMER_ID_WAIT_FOR_ECHO);
 
   try {
     delete msg;
 
-    thread.add_timer(TIMER_ID_NEED_LIFE_CHECK,
-                     ctimespec().expire_in(timeout_lifecheck));
+    thread->add_timer(this, TIMER_ID_NEED_LIFE_CHECK,
+                      ctimespec().expire_in(timeout_lifecheck));
 
   } catch (std::runtime_error &e) {
     VLOG(1) << __FUNCTION__ << " runtime error: " << e.what()
@@ -1160,18 +1163,18 @@ void crofconn::handle_recv(crofsock &socket, rofl::openflow::cofmsg *msg) {
   /* wakeup working thread in state ESTABLISHED; otherwise keep sleeping
    * and enqueue message until state ESTABLISHED is reached */
   if ((STATE_ESTABLISHED == state) && (not rx_thread_working)) {
-    thread.wakeup();
+    thread->notify_wake(wake_handle);
   }
 }
 
-void crofconn::handle_wakeup(cthread &thread) { handle_rx_messages(); }
+void crofconn::handle_wakeup(void *userdata) { handle_rx_messages(); }
 
 void crofconn::handle_rx_messages() {
   /* we start with handling incoming messages */
   rx_thread_working = true;
   rx_thread_scheduled = false;
 
-  thread.drop_timer(TIMER_ID_NEED_LIFE_CHECK);
+  thread->drop_timer(this, TIMER_ID_NEED_LIFE_CHECK);
 
   unsigned int keep_running = 1;
 
@@ -1232,7 +1235,7 @@ void crofconn::handle_rx_messages() {
 
         /* reschedule this method */
         if (not rxqueues[queue_id].empty()) {
-          thread.wakeup();
+          thread->notify_wake(wake_handle);
         }
       }
 
@@ -1256,8 +1259,8 @@ void crofconn::handle_rx_messages() {
 
   rx_thread_working = false;
 
-  thread.add_timer(TIMER_ID_NEED_LIFE_CHECK,
-                   ctimespec().expire_in(timeout_lifecheck));
+  thread->add_timer(this, TIMER_ID_NEED_LIFE_CHECK,
+                    ctimespec().expire_in(timeout_lifecheck));
 
   /* reenable reception of messages on socket */
   if (rofsock.is_rx_disabled()) {

--- a/src/rofl/common/crofconn.cc
+++ b/src/rofl/common/crofconn.cc
@@ -1166,10 +1166,10 @@ void crofconn::handle_recv(crofsock &socket, rofl::openflow::cofmsg *msg) {
       };
       }
     } break;
-    default: {
+    default:
+      VLOG(3) << __FUNCTION__ << ": invalid version, droppping msg=" << msg;
       delete msg;
       return;
-    };
     }
 
   } catch (eRofQueueFull &e) {

--- a/src/rofl/common/crofconn.h
+++ b/src/rofl/common/crofconn.h
@@ -1170,6 +1170,8 @@ private:
   // timeout value for ECHO.request messages
   time_t timeout_echo;
   static const time_t DEFAULT_ECHO_TIMEOUT;
+  static const time_t DEFAULT_ECHO_TIMEOUT_MISS_MAX;
+  int missed_echo;
 
   // timeout value for lifecheck
   time_t timeout_lifecheck;

--- a/src/rofl/common/crofctl.cc
+++ b/src/rofl/common/crofctl.cc
@@ -20,8 +20,8 @@ using namespace rofl;
 
 crofctl::~crofctl(){};
 
-crofctl::crofctl(crofctl_env *env, const cctlid &ctlid)
-    : env(env), ctlid(ctlid), rofchan(this), xid_last(random.uint32()),
+crofctl::crofctl(cthread *thread, crofctl_env *env, const cctlid &ctlid)
+    : env(env), ctlid(ctlid), rofchan(thread, this), xid_last(random.uint32()),
       async_config_role_default_template(rofl::openflow13::OFP_VERSION),
       async_config(rofl::openflow13::OFP_VERSION) {
   init_async_config_role_default_template();

--- a/src/rofl/common/crofctl.h
+++ b/src/rofl/common/crofctl.h
@@ -304,8 +304,9 @@ protected:
    * @param auxid control connection identifier
    * @param msg OpenFlow message instance
    */
-  void handle_stats_request(rofl::crofctl &ctl, const rofl::cauxid &auxid,
-                            rofl::openflow::cofmsg_stats_request &msg){};
+  virtual void
+  handle_stats_request(rofl::crofctl &ctl, const rofl::cauxid &auxid,
+                       rofl::openflow::cofmsg_stats_request &msg){};
 
   /**
    * @brief	OpenFlow Desc-Stats-Request message received.
@@ -667,7 +668,7 @@ public:
    * for this object
    * @param ctlid rofl-common's internal identifier for this instance
    */
-  crofctl(crofctl_env *env, const cctlid &ctlid);
+  crofctl(cthread *thread, crofctl_env *env, const cctlid &ctlid);
 
 public:
   /**

--- a/src/rofl/common/crofctl.h
+++ b/src/rofl/common/crofctl.h
@@ -1121,7 +1121,7 @@ public:
    */
   rofl::crofsock::msg_result_t
   send_error_message(const rofl::cauxid &auxid, uint32_t xid, uint16_t type,
-                     uint16_t code, uint8_t *data = NULL, size_t datalen = 0);
+                     uint16_t code, uint8_t *data = nullptr, size_t datalen = 0);
 
   /**
    * @brief	Sends OpenFlow Experimenter message to attached controller
@@ -1137,7 +1137,7 @@ public:
   rofl::crofsock::msg_result_t
   send_experimenter_message(const rofl::cauxid &auxid, uint32_t xid,
                             uint32_t experimenter_id, uint32_t exp_type,
-                            uint8_t *body = NULL, size_t bodylen = 0,
+                            uint8_t *body = nullptr, size_t bodylen = 0,
                             int timeout_in_secs = DEFAULT_REQUEST_TIMEOUT);
 
   /**

--- a/src/rofl/common/crofdpt.cc
+++ b/src/rofl/common/crofdpt.cc
@@ -20,8 +20,9 @@ using namespace rofl;
 
 crofdpt::~crofdpt(){};
 
-crofdpt::crofdpt(rofl::crofdpt_env *env, const rofl::cdptid &dptid)
-    : env(env), dptid(dptid), snoop(true), rofchan(this),
+crofdpt::crofdpt(cthread *thread, rofl::crofdpt_env *env,
+                 const rofl::cdptid &dptid)
+    : env(env), dptid(dptid), snoop(true), rofchan(thread, this),
       xid_last(random.uint32()), n_buffers(0), n_tables(0), capabilities(0),
       miss_send_len(0), flags(0){};
 

--- a/src/rofl/common/crofdpt.cc
+++ b/src/rofl/common/crofdpt.cc
@@ -461,7 +461,7 @@ void crofdpt::multipart_reply_rcvd(const rofl::cauxid &auxid,
                                    rofl::openflow::cofmsg *msg) {
   rofl::openflow::cofmsg_stats_reply *reply =
       dynamic_cast<rofl::openflow::cofmsg_stats_reply *>(msg);
-  assert(reply != NULL);
+  assert(reply != nullptr);
 
   switch (reply->get_stats_type()) {
   case rofl::openflow13::OFPMP_DESC: {

--- a/src/rofl/common/crofdpt.h
+++ b/src/rofl/common/crofdpt.h
@@ -894,7 +894,7 @@ public:
    * for this object
    * @param dptid rofl-common's internal identifier for this instance
    */
-  crofdpt(rofl::crofdpt_env *env, const rofl::cdptid &dptid);
+  crofdpt(cthread *thread, rofl::crofdpt_env *env, const rofl::cdptid &dptid);
 
 public:
   /**

--- a/src/rofl/common/crofdpt.h
+++ b/src/rofl/common/crofdpt.h
@@ -1032,7 +1032,7 @@ public:
   void drop_buffer(const rofl::cauxid &auxid, uint32_t buffer_id,
                    uint32_t inport = rofl::openflow::OFPP_CONTROLLER) {
     rofl::openflow::cofactions actions(get_version());
-    send_packet_out_message(auxid, buffer_id, inport, actions, NULL, 0);
+    send_packet_out_message(auxid, buffer_id, inport, actions, nullptr, 0);
   };
 
   /**@}*/
@@ -1412,7 +1412,7 @@ public:
    */
   rofl::crofsock::msg_result_t send_packet_out_message(
       const rofl::cauxid &auxid, uint32_t buffer_id, uint32_t in_port,
-      const rofl::openflow::cofactions &actions, uint8_t *data = NULL,
+      const rofl::openflow::cofactions &actions, uint8_t *data = nullptr,
       size_t datalen = 0, uint32_t *xid = nullptr);
 
   /**
@@ -1599,7 +1599,7 @@ public:
    */
   rofl::crofsock::msg_result_t
   send_error_message(const rofl::cauxid &auxid, uint32_t xid, uint16_t type,
-                     uint16_t code, uint8_t *data = NULL, size_t datalen = 0);
+                     uint16_t code, uint8_t *data = nullptr, size_t datalen = 0);
 
   /**
    * @brief	Sends OpenFlow Experimenter message to attached datapath
@@ -1618,7 +1618,7 @@ public:
   rofl::crofsock::msg_result_t
   send_experimenter_message(const rofl::cauxid &auxid, uint32_t xid,
                             uint32_t exp_id, uint32_t exp_type,
-                            uint8_t *body = NULL, size_t bodylen = 0,
+                            uint8_t *body = nullptr, size_t bodylen = 0,
                             int timeout_in_secs = DEFAULT_REQUEST_TIMEOUT);
 
   /**@}*/

--- a/src/rofl/common/crofqueue.h
+++ b/src/rofl/common/crofqueue.h
@@ -111,7 +111,7 @@ public:
    *
    */
   rofl::openflow::cofmsg *retrieve() {
-    rofl::openflow::cofmsg *msg = (rofl::openflow::cofmsg *)0;
+    rofl::openflow::cofmsg *msg = nullptr;
     AcquireReadWriteLock rwlock(queue_lock);
     if (queue.empty()) {
       return msg;
@@ -125,7 +125,7 @@ public:
    *
    */
   rofl::openflow::cofmsg *front() {
-    rofl::openflow::cofmsg *msg = (rofl::openflow::cofmsg *)0;
+    rofl::openflow::cofmsg *msg = nullptr;
     AcquireReadWriteLock rwlock(queue_lock);
     if (queue.empty()) {
       return msg;

--- a/src/rofl/common/crofsock.cc
+++ b/src/rofl/common/crofsock.cc
@@ -37,7 +37,7 @@ crofsock::crofsock(cthread *thread, crofsock_env *env)
       reconnect_backoff_start(1 /*secs*/),
       reconnect_backoff_current(1 /*secs*/), reconnect_counter(0), sd(-1),
       domain(AF_INET), type(SOCK_STREAM), protocol(IPPROTO_TCP), backlog(64),
-      ctx(NULL), ssl(NULL), bio(NULL), capath("."), cafile("ca.pem"),
+      ctx(nullptr), ssl(nullptr), bio(nullptr), capath("."), cafile("ca.pem"),
       certfile("crt.pem"), keyfile("key.pem"), password(""),
       verify_mode("PEER"), verify_depth("1"),
       ciphers("EECDH+ECDSA+AESGCM EECDH+aRSA+AESGCM EECDH+ECDSA+SHA256 "
@@ -145,7 +145,7 @@ void crofsock::close() {
 
     if (ssl) {
       SSL_free(ssl);
-      ssl = NULL;
+      ssl = nullptr;
     }
     tls_destroy_context();
     flag_set(FLAG_TLS_IN_USE, false);
@@ -162,7 +162,7 @@ void crofsock::close() {
 
     if (ssl) {
       SSL_free(ssl);
-      ssl = NULL;
+      ssl = nullptr;
     }
     tls_destroy_context();
     flag_set(FLAG_TLS_IN_USE, false);
@@ -184,7 +184,7 @@ void crofsock::close() {
     if (ssl) {
       SSL_shutdown(ssl);
       SSL_free(ssl);
-      ssl = NULL;
+      ssl = nullptr;
     }
     tls_destroy_context();
     flag_set(FLAG_TLS_IN_USE, false);
@@ -655,8 +655,8 @@ void crofsock::tls_init_context() {
 
   // capath/cafile
   if (!SSL_CTX_load_verify_locations(ctx,
-                                     cafile.empty() ? NULL : cafile.c_str(),
-                                     capath.empty() ? NULL : capath.c_str())) {
+                                     cafile.empty() ? nullptr : cafile.c_str(),
+                                     capath.empty() ? nullptr : capath.c_str())) {
     throw eLibCall("eLibCall", "SSL_CTX_load_verify_locations", __FILE__,
                    __FUNCTION__, __LINE__)
         .set_key("cafile", cafile)
@@ -670,7 +670,7 @@ void crofsock::tls_init_context() {
     mode = SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
   }
 
-  SSL_CTX_set_verify(ctx, mode, NULL);
+  SSL_CTX_set_verify(ctx, mode, nullptr);
 
   int depth;
   std::istringstream(verify_depth) >> depth;
@@ -681,14 +681,14 @@ void crofsock::tls_init_context() {
 void crofsock::tls_destroy_context() {
   if (ctx) {
     SSL_CTX_free(ctx);
-    ctx = NULL;
+    ctx = nullptr;
   }
 
   tls_destroy();
 }
 
 int crofsock::tls_pswd_cb(char *buf, int size, int rwflag, void *userdata) {
-  if (userdata == NULL)
+  if (userdata == nullptr)
     return 0;
 
   crofsock &socket = *(static_cast<crofsock *>(userdata));
@@ -717,11 +717,11 @@ void crofsock::tls_accept(int sockfd) {
 
     tls_init_context();
 
-    if ((ssl = SSL_new(ctx)) == NULL) {
+    if ((ssl = SSL_new(ctx)) == nullptr) {
       throw eLibCall("eLibCall", "SSL_new", __FILE__, __FUNCTION__, __LINE__);
     }
 
-    if ((bio = BIO_new(BIO_s_socket())) == NULL) {
+    if ((bio = BIO_new(BIO_s_socket())) == nullptr) {
       throw eLibCall("eLibCall", "BIO_new", __FILE__, __FUNCTION__, __LINE__);
     }
 
@@ -776,8 +776,8 @@ void crofsock::tls_accept(int sockfd) {
       tls_log_errors();
 
       SSL_free(ssl);
-      ssl = NULL;
-      bio = NULL;
+      ssl = nullptr;
+      bio = nullptr;
 
       tls_destroy_context();
 
@@ -793,8 +793,8 @@ void crofsock::tls_accept(int sockfd) {
         tls_log_errors();
 
         SSL_free(ssl);
-        ssl = NULL;
-        bio = NULL;
+        ssl = nullptr;
+        bio = nullptr;
 
         tls_destroy_context();
 
@@ -838,11 +838,11 @@ void crofsock::tls_connect(bool reconnect) {
 
     tls_init_context();
 
-    if ((ssl = SSL_new(ctx)) == NULL) {
+    if ((ssl = SSL_new(ctx)) == nullptr) {
       throw eLibCall("eLibCall", "SSL_new", __FILE__, __FUNCTION__, __LINE__);
     }
 
-    if ((bio = BIO_new(BIO_s_socket())) == NULL) {
+    if ((bio = BIO_new(BIO_s_socket())) == nullptr) {
       throw eLibCall("eLibCall", "BIO_new", __FILE__, __FUNCTION__, __LINE__);
     }
 
@@ -899,8 +899,8 @@ void crofsock::tls_connect(bool reconnect) {
       tls_log_errors();
 
       SSL_free(ssl);
-      ssl = NULL;
-      bio = NULL;
+      ssl = nullptr;
+      bio = nullptr;
 
       tls_destroy_context();
 
@@ -916,8 +916,8 @@ void crofsock::tls_connect(bool reconnect) {
         tls_log_errors();
 
         SSL_free(ssl);
-        ssl = NULL;
-        bio = NULL;
+        ssl = nullptr;
+        bio = nullptr;
 
         tls_destroy_context();
 
@@ -957,15 +957,15 @@ bool crofsock::tls_verify_ok() {
     /*
      * there must be a certificate presented by the peer in mode SSL_VERIFY_PEER
      */
-    X509 *cert = (X509 *)NULL;
-    if ((cert = SSL_get_peer_certificate(ssl)) == NULL) {
+    X509 *cert = (X509 *)nullptr;
+    if ((cert = SSL_get_peer_certificate(ssl)) == nullptr) {
 
       VLOG(2) << __FUNCTION__ << " TLS: no certificate presented by peer";
       tls_log_errors();
 
       SSL_free(ssl);
-      ssl = NULL;
-      bio = NULL;
+      ssl = nullptr;
+      bio = nullptr;
 
       tls_destroy_context();
 
@@ -1445,7 +1445,7 @@ void crofsock::send_from_queue() {
         rofl::openflow::cofmsg *msg = nullptr;
 
         /* fetch a new message for transmission from tx queue */
-        if ((msg = txqueues[queue_id].retrieve()) == NULL) {
+        if ((msg = txqueues[queue_id].retrieve()) == nullptr) {
           VLOG(4) << __FUNCTION__ << ": skipping queue_id=" << queue_id
                   << " (empty)";
           break;

--- a/src/rofl/common/crofsock.cc
+++ b/src/rofl/common/crofsock.cc
@@ -623,7 +623,7 @@ void crofsock::tls_init_context() {
     tls_destroy_context();
   }
 
-  ctx = SSL_CTX_new(TLSv1_2_method());
+  ctx = SSL_CTX_new(TLS_method());
 
   // certificate
   if (!SSL_CTX_use_certificate_file(ctx, certfile.c_str(), SSL_FILETYPE_PEM)) {

--- a/src/rofl/common/crofsock.cc
+++ b/src/rofl/common/crofsock.cc
@@ -27,6 +27,9 @@ enum sock_use { sock_rx = 1, sock_tx = 2 };
 /*static*/ bool crofsock::tls_initialized = false;
 
 crofsock::~crofsock() {
+  thread->remove_wakeup_observer(this, wh_rx); // rx
+  thread->remove_wakeup_observer(this, wh_tx); // tx
+  wh_tx = wh_rx = 0;
   thread->drop_timer(this, cthread::ALL_TIMERS);
   close();
 }
@@ -60,9 +63,6 @@ crofsock::crofsock(cthread *thread, crofsock_env *env)
 }
 
 void crofsock::close_sockets() {
-  thread->remove_wakeup_observer(this, wh_rx); // rx
-  thread->remove_wakeup_observer(this, wh_tx); // tx
-  wh_tx = wh_rx = 0;
   if (sd > 0) {
     thread->drop_read_fd(sd);  // rx
     thread->drop_write_fd(sd); // tx

--- a/src/rofl/common/crofsock.cc
+++ b/src/rofl/common/crofsock.cc
@@ -26,7 +26,10 @@ enum sock_use { sock_rx = 1, sock_tx = 2 };
 /*static*/ crwlock crofsock::rwlock;
 /*static*/ bool crofsock::tls_initialized = false;
 
-crofsock::~crofsock() { close(); }
+crofsock::~crofsock() {
+  thread->drop_timer(this, cthread::ALL_TIMERS);
+  close();
+}
 
 crofsock::crofsock(cthread *thread, crofsock_env *env)
     : env(env), state(STATE_IDLE), mode(MODE_UNKNOWN), thread(thread), wh_rx(0),

--- a/src/rofl/common/crofsock.cc
+++ b/src/rofl/common/crofsock.cc
@@ -1204,6 +1204,8 @@ void crofsock::rx_disable() {
   switch (state.load()) {
   case STATE_TCP_ESTABLISHED:
   case STATE_TLS_ESTABLISHED: {
+    thread->drop_read_fd(sd);  // rx
+    thread->drop_write_fd(sd); // tx
     VLOG(2) << __FUNCTION__ << " disable reception laddr=" << laddr.str()
             << " raddr=" << raddr.str();
   } break;
@@ -1680,7 +1682,7 @@ void crofsock::handle_read_event_rxthread(int fd) {
 
 void crofsock::recv_message() {
   int recv_msg_cnt = 50;
-  while (not rx_disabled && recv_msg_cnt--) {
+  while (not rx_disabled && state > STATE_TCP_CONNECTING && recv_msg_cnt--) {
     VLOG(4) << __FUNCTION__ << ": fd=" << sd << " laddr=" << laddr.str()
             << " raddr=" << raddr.str() << " state=" << state;
 

--- a/src/rofl/common/crofsock.h
+++ b/src/rofl/common/crofsock.h
@@ -284,7 +284,7 @@ public:
   /**
    *
    */
-  virtual void close();
+  void close();
 
   /**
    *

--- a/src/rofl/common/csegment.cpp
+++ b/src/rofl/common/csegment.cpp
@@ -14,9 +14,9 @@
 using namespace rofl;
 
 void csegment::clone(const rofl::openflow::cofmsg &msg_stats) {
-  if (NULL != msg) {
+  if (nullptr != msg) {
     delete msg;
-    msg = NULL;
+    msg = nullptr;
   }
 
   uint16_t stats_type = 0;
@@ -111,7 +111,7 @@ void csegment::clone(const rofl::openflow::cofmsg &msg_stats) {
     };
     }
 
-    if (NULL != msg) {
+    if (nullptr != msg) {
       if (dynamic_cast<rofl::openflow::cofmsg_stats_request *>(msg)) {
         rofl::openflow::cofmsg_stats_request &req =
             dynamic_cast<rofl::openflow::cofmsg_stats_request &>(*msg);
@@ -204,7 +204,7 @@ void csegment::clone(const rofl::openflow::cofmsg &msg_stats) {
     };
     }
 
-    if (NULL != msg) {
+    if (nullptr != msg) {
       if (dynamic_cast<rofl::openflow::cofmsg_stats_request *>(msg)) {
         rofl::openflow::cofmsg_stats_request &req =
             dynamic_cast<rofl::openflow::cofmsg_stats_request &>(*msg);
@@ -226,7 +226,7 @@ void csegment::clone(const rofl::openflow::cofmsg &msg_stats) {
 }
 
 void csegment::store_and_merge_msg(const rofl::openflow::cofmsg &msg_stats) {
-  if (NULL == msg) {
+  if (nullptr == msg) {
 
     csegment::clone(msg_stats);
 
@@ -440,6 +440,6 @@ void csegment::store_and_merge_msg(const rofl::openflow::cofmsg &msg_stats) {
 
 rofl::openflow::cofmsg *csegment::retrieve_and_detach_msg() {
   rofl::openflow::cofmsg *tmp = msg;
-  msg = NULL;
+  msg = nullptr;
   return tmp;
 }

--- a/src/rofl/common/csegment.hpp
+++ b/src/rofl/common/csegment.hpp
@@ -88,10 +88,10 @@ public:
       return *this;
     tspec = segment.tspec;
     xid = segment.xid;
-    if (NULL != segment.msg) {
+    if (nullptr != segment.msg) {
       csegment::clone(*(segment.msg));
     } else {
-      msg = NULL;
+      msg = nullptr;
     }
     msg_type = segment.msg_type;
     msg_multipart_type = segment.msg_multipart_type;

--- a/src/rofl/common/cthread.cpp
+++ b/src/rofl/common/cthread.cpp
@@ -145,9 +145,8 @@ void cthread::release() {
 
 int cthread::add_wakeup_observer(cthread_wakeup_event *cb, int *handle,
                                  void *userdata) {
-  assert(handle);
-
-  VLOG(2) << __FUNCTION__ << ": cb=" << cb << " handle=" << *handle;
+  if (handle == nullptr)
+    LOG(FATAL) << __FUNCTION__ << ": handle cannot be null";
 
   event *ev = new event(cb, userdata);
   if (ev->get_fd() == -1) {
@@ -193,6 +192,8 @@ int cthread::add_wakeup_observer(cthread_wakeup_event *cb, int *handle,
   }
 
   *handle = ev->get_fd();
+  VLOG(2) << __FUNCTION__ << ": added cb=" << cb << " fd=" << *handle
+          << " (handle)";
 
   return 0;
 }

--- a/src/rofl/common/cthread.cpp
+++ b/src/rofl/common/cthread.cpp
@@ -16,9 +16,6 @@
 
 using namespace rofl;
 
-/*static*/ const int cthread::PIPE_READ_FD = 0;
-/*static*/ const int cthread::PIPE_WRITE_FD = 1;
-
 void cthread::initialize() {
   running = false;
   tid = 0;

--- a/src/rofl/common/cthread.cpp
+++ b/src/rofl/common/cthread.cpp
@@ -90,7 +90,9 @@ public:
   void *userdata_re;
   void *userdata_we;
   event *ev;
-  io_event() : re(nullptr), we(nullptr), ev(nullptr) {}
+  io_event()
+      : re(nullptr), we(nullptr), userdata_re(nullptr), userdata_we(nullptr),
+        ev(nullptr) {}
   io_event(const io_event &e) : event_base(e) {
     this->re = e.re;
     this->we = e.we;
@@ -601,7 +603,7 @@ void cthread::start(const std::string &thread_name) {
   case STATE_IDLE: {
 
     running = true;
-    if (pthread_create(&tid, NULL, &(cthread::start_loop), this) < 0) {
+    if (pthread_create(&tid, nullptr, &(cthread::start_loop), this) < 0) {
       throw eSysCall("eSysCall", "pthread_create", __FILE__, __FUNCTION__,
                      __LINE__);
     }
@@ -630,7 +632,7 @@ void cthread::stop() {
       return;
     }
 
-    int rv = pthread_join(tid, NULL);
+    int rv = pthread_join(tid, nullptr);
     if (rv != 0) {
       pthread_cancel(tid);
     }

--- a/src/rofl/common/cthread.cpp
+++ b/src/rofl/common/cthread.cpp
@@ -14,41 +14,101 @@
 #include <iostream>
 #include <sys/eventfd.h>
 
-using namespace rofl;
+namespace rofl {
+
+class event : public cthread_read_event {
+public:
+  event(cthread_wakeup_event *, void *userdata);
+  ~event();
+  int get_fd() const { return event_fd; }
+  cthread_wakeup_event *get_wev() const { return wake; }
+  void notifiy_one();
+
+  void handle_read(int fd, void *userdata) override;
+
+private:
+  cthread_wakeup_event *wake;
+  void *userdata;
+  int event_fd;
+};
+
+event::event(cthread_wakeup_event *wake, void *userdata)
+    : wake(wake), userdata(userdata) {
+  event_fd = eventfd(0, 0);
+  if (event_fd == -1) {
+    switch (errno) {
+    case EMFILE:
+    case ENFILE:
+    case ENODEV:
+    case ENOMEM:
+    default:
+      LOG(ERROR) << __FUNCTION__
+                 << ": failed to create eventfd: " << strerror(errno);
+    }
+  }
+  VLOG(3) << __FUNCTION__ << ": event_fd=" << event_fd;
+}
+event::~event() {
+  if (event_fd != -1)
+    close(event_fd);
+}
+void event::notifiy_one() {
+  // XXX(toanju): notify invalid initilization
+  uint64_t c = 1;
+  ssize_t rv = write(event_fd, &c, sizeof(c));
+  (void)rv;
+}
+void event::handle_read(int fd, void *userdata) {
+  assert(fd == event_fd);
+  assert(userdata == this->userdata);
+  uint64_t c;
+  ssize_t rv = read(event_fd, &c, sizeof(c));
+  (void)rv;
+
+  if (wake) {
+    wake->handle_wakeup(this->userdata);
+  }
+}
+
+class event_base {
+public:
+  int fd;
+
+  event_base(const event_base &e) { fd = e.fd; }
+
+  event_base() {}
+  virtual ~event_base() {}
+};
+
+class io_event : public event_base {
+public:
+  cthread_read_event *re;
+  cthread_write_event *we;
+  void *userdata_re;
+  void *userdata_we;
+  event *ev;
+  io_event() : re(nullptr), we(nullptr), ev(nullptr) {}
+  io_event(const io_event &e) : event_base(e) {
+    this->re = e.re;
+    this->we = e.we;
+    this->userdata_re = e.userdata_re;
+    this->userdata_we = e.userdata_we;
+    this->ev = nullptr; // never copy this
+  }
+};
 
 void cthread::initialize() {
   running = false;
   tid = 0;
+  events_reg.resize(max_fds);
 
-  // worker thread
+  // event loop
   if ((epfd = epoll_create(1)) < 0) {
     throw eSysCall("eSysCall", "epoll_create", __FILE__, __FUNCTION__,
                    __LINE__);
   }
 
-  // eventfd
-  event_fd = eventfd(0, EFD_NONBLOCK);
-  if (event_fd < 0) {
-    throw eSysCall("eSysCall", "eventfd", __FILE__, __FUNCTION__, __LINE__);
-  }
-
-  // register event_fd to kernel
-  struct epoll_event epev;
-  memset((uint8_t *)&epev, 0, sizeof(struct epoll_event));
-  epev.events = EPOLLIN; // level-triggered
-  epev.data.fd = event_fd;
-
-  if (epoll_ctl(epfd, EPOLL_CTL_ADD, event_fd, &epev) < 0) {
-    switch (errno) {
-    case EEXIST: {
-      /* do nothing */
-    } break;
-    default: {
-      throw eSysCall("eSysCall", "epoll_ctl (EPOLL_CTL_ADD)", __FILE__,
-                     __FUNCTION__, __LINE__);
-    };
-    }
-  }
+  add_wakeup_observer(nullptr, &wake_handle);
 }
 
 void cthread::release() {
@@ -56,48 +116,144 @@ void cthread::release() {
 
   stop();
 
+  remove_wakeup_observer(nullptr, wake_handle);
+
   {
     AcquireReadWriteLock lock(tlock);
     for (auto it : fds) {
       struct epoll_event epev;
-      memset((uint8_t *)&epev, 0, sizeof(struct epoll_event));
+      memset(&epev, 0, sizeof(struct epoll_event));
       epev.events = 0;
       epev.data.fd = it.first;
       epoll_ctl(epfd, EPOLL_CTL_DEL, it.first, &epev);
+
+      if (events_reg[it.first]) {
+        delete events_reg[it.first];
+        events_reg[it.first] = nullptr;
+      }
     }
     fds.clear();
   }
 
-  // deregister event_fd from kernel
-  struct epoll_event epev;
-  memset((uint8_t *)&epev, 0, sizeof(struct epoll_event));
-  epev.events = 0;
-  epev.data.fd = event_fd;
+  ::close(epfd);
+}
 
-  if (epoll_ctl(epfd, EPOLL_CTL_DEL, event_fd, &epev) < 0) {
+int cthread::add_wakeup_observer(cthread_wakeup_event *cb, int *handle,
+                                 void *userdata) {
+  assert(handle);
+
+  VLOG(2) << __FUNCTION__ << ": cb=" << cb << " handle=" << *handle;
+
+  event *ev = new event(cb, userdata);
+  if (ev->get_fd() == -1) {
+    VLOG(1) << __FUNCTION__ << ": invalid fd";
+    delete ev;
+    return -EIO;
+  }
+
+  if (events_reg[ev->get_fd()] == nullptr) {
+    io_event *wue = new io_event();
+    wue->fd = ev->get_fd();
+    wue->ev = ev;
+    wue->re = ev;
+    wue->userdata_re = userdata;
+    events_reg[ev->get_fd()] = wue;
+    VLOG(2) << __FUNCTION__ << ": fd=" << ev->get_fd();
+  } else {
+    delete ev;
+    LOG(FATAL) << __FUNCTION__ << ": already registered";
+    return -EEXIST;
+  }
+
+  // XXX(toanju): use add_fd
+  // register fd
+  struct epoll_event epev;
+  memset(&epev, 0, sizeof(struct epoll_event));
+  epev.events = EPOLLIN;
+  epev.data.fd = ev->get_fd();
+
+  if (epoll_ctl(epfd, EPOLL_CTL_ADD, ev->get_fd(), &epev) < 0) {
     switch (errno) {
-    case ENOENT: {
-      /* do nothing */
-    } break;
-    default: {
-      throw eSysCall("eSysCall", "epoll_ctl (EPOLL_CTL_DEL)", __FILE__,
-                     __FUNCTION__, __LINE__);
-    };
+    case ENOMEM:
+    case ENOSPC:
+      delete events_reg[ev->get_fd()];
+      events_reg[ev->get_fd()] = nullptr;
+      delete ev;
+      return -errno;
+      break;
+    default:
+      assert(0 && "not reached");
+      break;
     }
   }
 
-  ::close(epfd);
-  ::close(event_fd);
+  *handle = ev->get_fd();
+
+  return 0;
+}
+
+int cthread::remove_wakeup_observer(cthread_wakeup_event *cb, int handle) {
+  int rv = -EINVAL;
+
+  VLOG(2) << __FUNCTION__ << ": cb=" << cb << " handle=" << handle;
+
+  if (handle <= 0 || handle > max_fds)
+    return rv;
+
+  if (events_reg[handle]) {
+    AcquireReadWriteLock lock(events_lock);
+    io_event *ev = static_cast<io_event *>(events_reg[handle]);
+
+    if (ev && ev->ev && ev->ev->get_wev() == cb) {
+      // deregister fd from kernel
+      struct epoll_event epev;
+      memset(&epev, 0, sizeof(struct epoll_event));
+      epev.events = 0;
+      epev.data.fd = handle;
+
+      epoll_ctl(epfd, EPOLL_CTL_DEL, handle, &epev);
+
+      delete ev->ev;
+      delete ev;
+      events_reg[handle] = nullptr;
+      rv = 0;
+    } else {
+      VLOG(2) << __FUNCTION__ << ": invalid cb=" << cb;
+    }
+  }
+
+  return rv;
+}
+
+int cthread::notify_wake(int handle) {
+  int rv = -EINVAL;
+
+  VLOG(3) << __FUNCTION__ << ": trying to wake fd=" << handle;
+
+  if (handle < 0 || handle > max_fds)
+    return rv;
+
+  if (events_reg[handle]) {
+    io_event *ev = static_cast<io_event *>(events_reg[handle]);
+    if (ev->ev && ev->ev->get_fd() == handle) {
+      ev->ev->notifiy_one();
+      rv = 0;
+    }
+  }
+
+  return rv;
 }
 
 void cthread::add_fd(int fd, bool exception, bool edge_triggered) {
   AcquireReadWriteLock lock(tlock);
-  if (fds.find(fd) != fds.end())
+  if (fds.find(fd) != fds.end()) {
+    VLOG(3) << __FUNCTION__ << ": fd=" << fd << " already added";
     return;
+  }
 
   uint32_t events = edge_triggered ? EPOLLET : 0;
   struct epoll_event epev;
-  memset((uint8_t *)&epev, 0, sizeof(struct epoll_event));
+  memset(&epev, 0, sizeof(struct epoll_event));
   epev.events = events;
   epev.data.fd = fd;
 
@@ -126,10 +282,10 @@ void cthread::drop_fd(int fd, bool exception) {
     return;
 
   struct epoll_event epev;
-  memset((uint8_t *)&epev, 0, sizeof(struct epoll_event));
+  memset(&epev, 0, sizeof(struct epoll_event));
   epev.data.fd = fd;
 
-  VLOG(3) << __FUNCTION__ << " fd=" << fd << " thread=" << this;
+  VLOG(3) << __FUNCTION__ << ": fd=" << fd << " thread=" << this;
 
   if (epoll_ctl(epfd, EPOLL_CTL_DEL, fd, &epev) < 0) {
     switch (errno) {
@@ -147,7 +303,35 @@ void cthread::drop_fd(int fd, bool exception) {
   fds.erase(fd);
 }
 
-void cthread::add_read_fd(int fd, bool exception, bool edge_triggered) {
+void cthread::add_read_fd(int fd, cthread_read_event *cb, void *userdata,
+                          bool exception, bool edge_triggered) {
+
+  if ((unsigned)fd >= events_reg.capacity()) {
+    VLOG(2) << "XXX";
+    return; // XXX(toanju): return values should be added
+  }
+
+  io_event *ioev = static_cast<io_event *>(events_reg[fd]);
+
+  if (ioev == nullptr) {
+    io_event *e = new io_event();
+    e->fd = fd;
+    e->re = cb;
+    e->userdata_re = userdata;
+    events_reg[fd] = e;
+    VLOG(2) << __FUNCTION__ << ": fd=" << fd << " cb=" << cb
+            << " userdata=" << userdata;
+  } else if (ioev->re == nullptr) {
+    ioev->re = cb;
+    ioev->userdata_re = userdata;
+    VLOG(2) << __FUNCTION__ << ": fd=" << fd << " cb=" << cb
+            << " userdata=" << userdata;
+  } else {
+    // XXX(toanju): log error?
+    VLOG(2) << __FUNCTION__ << ": already registered fd=" << fd << " cb=" << cb;
+    assert(cb == ioev->re);
+  }
+
   add_fd(fd, exception, edge_triggered);
 
   AcquireReadWriteLock lock(tlock);
@@ -161,47 +345,90 @@ void cthread::add_read_fd(int fd, bool exception, bool edge_triggered) {
 
   if (epoll_ctl(epfd, EPOLL_CTL_MOD, fd, &epev) < 0) {
     switch (errno) {
-    case ENOENT: {
+    case ENOENT:
       epoll_ctl(epfd, EPOLL_CTL_ADD, fd, &epev);
-    } break;
-    default: {
+      break;
+    default:
       if (exception)
         throw eSysCall("eSysCall", "epoll_ctl (EPOLL_CTL_MOD)", __FILE__,
                        __FUNCTION__, __LINE__);
-    };
     }
   }
 }
 
 void cthread::drop_read_fd(int fd, bool exception) {
-  AcquireReadWriteLock lock(tlock);
-  if (fds.find(fd) == fds.end())
-    return;
+  {
+    AcquireReadWriteLock lock(tlock);
+    if (fds.find(fd) == fds.end())
+      return;
 
-  fds[fd] &= ~EPOLLIN;
+    fds[fd] &= ~EPOLLIN;
 
-  struct epoll_event epev;
-  memset((uint8_t *)&epev, 0, sizeof(struct epoll_event));
-  epev.events = fds[fd];
-  epev.data.fd = fd;
+    struct epoll_event epev;
+    memset((uint8_t *)&epev, 0, sizeof(struct epoll_event));
+    epev.events = fds[fd];
+    epev.data.fd = fd;
 
-  VLOG(3) << __FUNCTION__ << " fd=" << fd << " thread=" << this;
+    VLOG(3) << __FUNCTION__ << " fd=" << fd << " thread=" << this;
 
-  if (epoll_ctl(epfd, EPOLL_CTL_MOD, fd, &epev) < 0) {
-    switch (errno) {
-    case ENOENT: {
-      epoll_ctl(epfd, EPOLL_CTL_ADD, fd, &epev);
-    } break;
-    default: {
-      if (exception)
-        throw eSysCall("eSysCall", "epoll_ctl (EPOLL_CTL_MOD)", __FILE__,
-                       __FUNCTION__, __LINE__);
-    };
+    if (epoll_ctl(epfd, EPOLL_CTL_MOD, fd, &epev) < 0) {
+      switch (errno) {
+      case ENOENT:
+        epoll_ctl(epfd, EPOLL_CTL_ADD, fd, &epev);
+        break;
+      default:
+        if (exception)
+          throw eSysCall("eSysCall", "epoll_ctl (EPOLL_CTL_MOD)", __FILE__,
+                         __FUNCTION__, __LINE__);
+      }
+    }
+  }
+
+  AcquireReadWriteLock lock(events_lock);
+  if (events_reg[fd]) {
+    io_event *ioev = static_cast<io_event *>(events_reg[fd]);
+
+    VLOG(2) << __FUNCTION__ << ": fd=" << fd << " cb_read=" << ioev->re
+            << " cb_write=" << ioev->we;
+
+    if (ioev->we) {
+      ioev->re = nullptr;
+    } else {
+      delete events_reg[fd];
+      events_reg[fd] = nullptr;
+      drop_fd(fd);
     }
   }
 }
 
-void cthread::add_write_fd(int fd, bool exception, bool edge_triggered) {
+void cthread::add_write_fd(int fd, cthread_write_event *cb, void *userdata,
+                           bool exception, bool edge_triggered) {
+
+  if ((unsigned)fd >= events_reg.capacity()) {
+    VLOG(2) << __FUNCTION__ << ": XXX";
+    return; // XXX(toanju): return values should be added
+  }
+
+  io_event *ioev = static_cast<io_event *>(events_reg[fd]);
+
+  if (ioev == nullptr) {
+    ioev = new io_event();
+    ioev->fd = fd;
+    ioev->we = cb;
+    ioev->userdata_we = userdata;
+    events_reg[fd] = ioev;
+    VLOG(2) << __FUNCTION__ << ": fd=" << fd << " cb=" << cb
+            << " userdata=" << userdata;
+  } else if (ioev->we == nullptr) {
+    ioev->we = cb;
+    ioev->userdata_we = userdata;
+    VLOG(2) << __FUNCTION__ << ": fd=" << fd << " cb=" << cb
+            << " userdata=" << userdata;
+  } else {
+    // XXX(toanju): log error?
+    VLOG(2) << __FUNCTION__ << ": already registered fd=" << fd << " cb=" << cb;
+  }
+
   add_fd(fd, exception, edge_triggered);
 
   AcquireReadWriteLock lock(tlock);
@@ -228,29 +455,46 @@ void cthread::add_write_fd(int fd, bool exception, bool edge_triggered) {
 }
 
 void cthread::drop_write_fd(int fd, bool exception) {
-  AcquireReadWriteLock lock(tlock);
-  if (fds.find(fd) == fds.end())
-    return;
+  {
+    AcquireReadWriteLock lock(tlock);
+    if (fds.find(fd) == fds.end())
+      return;
 
-  fds[fd] &= ~EPOLLOUT;
+    fds[fd] &= ~EPOLLOUT;
 
-  struct epoll_event epev;
-  memset((uint8_t *)&epev, 0, sizeof(struct epoll_event));
-  epev.events = fds[fd];
-  epev.data.fd = fd;
+    struct epoll_event epev;
+    memset((uint8_t *)&epev, 0, sizeof(struct epoll_event));
+    epev.events = fds[fd];
+    epev.data.fd = fd;
 
-  VLOG(3) << __FUNCTION__ << " fd=" << fd << " thread=" << this;
+    VLOG(2) << __FUNCTION__ << " fd=" << fd << " thread=" << this;
 
-  if (epoll_ctl(epfd, EPOLL_CTL_MOD, fd, &epev) < 0) {
-    switch (errno) {
-    case ENOENT: {
-      epoll_ctl(epfd, EPOLL_CTL_ADD, fd, &epev);
-    } break;
-    default: {
-      if (exception)
-        throw eSysCall("eSysCall", "epoll_ctl (EPOLL_CTL_MOD)", __FILE__,
-                       __FUNCTION__, __LINE__);
-    };
+    if (epoll_ctl(epfd, EPOLL_CTL_MOD, fd, &epev) < 0) {
+      switch (errno) {
+      case ENOENT:
+        epoll_ctl(epfd, EPOLL_CTL_ADD, fd, &epev);
+        break;
+      default:
+        if (exception)
+          throw eSysCall("eSysCall", "epoll_ctl (EPOLL_CTL_MOD)", __FILE__,
+                         __FUNCTION__, __LINE__);
+      }
+    }
+  }
+
+  AcquireReadWriteLock lock(events_lock);
+  if (events_reg[fd]) {
+    io_event *ioev = static_cast<io_event *>(events_reg[fd]);
+
+    VLOG(2) << __FUNCTION__ << ": fd=" << fd << " cb_read=" << ioev->re
+            << " cb_write=" << ioev->we;
+
+    if (ioev->re) {
+      ioev->we = nullptr;
+    } else {
+      delete events_reg[fd];
+      events_reg[fd] = nullptr;
+      drop_fd(fd);
     }
   }
 }
@@ -260,9 +504,14 @@ void cthread::clear_timers() {
   ordered_timers.clear();
 };
 
-bool cthread::add_timer(uint32_t timer_id, const ctimespec &tspec) {
+bool cthread::add_timer(cthread_timeout_event *e, uint32_t timer_id,
+                        const ctimespec &tspec) {
   std::pair<std::set<ctimer>::iterator, bool> rv;
   bool do_wakeup = false;
+
+  VLOG(2) << __FUNCTION__ << ": e=" << e << " timer_id=" << timer_id << " "
+          << tspec;
+
   {
     AcquireReadWriteLock lock(tlock);
 
@@ -270,52 +519,54 @@ bool cthread::add_timer(uint32_t timer_id, const ctimespec &tspec) {
       do_wakeup = true;
 
     auto timer_it = find_if(ordered_timers.begin(), ordered_timers.end(),
-                            ctimer_find_by_timer_id(timer_id));
+                            ctimer_find_by_timer_and_event(e, timer_id));
     if (timer_it != ordered_timers.end()) {
       ordered_timers.erase(timer_it);
-      rv = ordered_timers.emplace(timer_id, tspec);
+      rv = ordered_timers.emplace(e, timer_id, tspec);
     } else {
-      rv = ordered_timers.emplace(timer_id, tspec);
+      rv = ordered_timers.emplace(e, timer_id, tspec);
     }
   }
 
+  // rearm timer
   if ((do_wakeup) && (tid != pthread_self())) {
-    wakeup();
+    notify_wake(wake_handle);
   }
 
   return rv.second;
 }
 
-const ctimer &cthread::get_timer(uint32_t timer_id) const {
+const ctimer &cthread::get_timer(cthread_timeout_event *e,
+                                 uint32_t timer_id) const {
   AcquireReadLock lock(tlock);
   auto timer_it = find_if(ordered_timers.begin(), ordered_timers.end(),
-                          ctimer_find_by_timer_id(timer_id));
+                          ctimer_find_by_timer_and_event(e, timer_id));
   if (timer_it == ordered_timers.end()) {
     throw eThreadNotFound("cthread::get_timer() timer_id not found");
   }
   return *timer_it;
 }
 
-bool cthread::drop_timer(uint32_t timer_id) {
+bool cthread::drop_timer(cthread_timeout_event *e, uint32_t timer_id) {
   AcquireReadWriteLock lock(tlock);
   auto timer_it = find_if(ordered_timers.begin(), ordered_timers.end(),
-                          ctimer_find_by_timer_id(timer_id));
+                          ctimer_find_by_timer_and_event(e, timer_id));
   if (timer_it == ordered_timers.end()) {
     return false;
   }
   ordered_timers.erase(timer_it);
 
   if (tid != pthread_self()) {
-    wakeup();
+    notify_wake(wake_handle);
   }
 
   return true;
 }
 
-bool cthread::has_timer(uint32_t timer_id) const {
+bool cthread::has_timer(cthread_timeout_event *e, uint32_t timer_id) const {
   AcquireReadLock lock(tlock);
   auto timer_it = find_if(ordered_timers.begin(), ordered_timers.end(),
-                          ctimer_find_by_timer_id(timer_id));
+                          ctimer_find_by_timer_and_event(e, timer_id));
   return (not(timer_it == ordered_timers.end()));
 }
 
@@ -345,7 +596,7 @@ void cthread::stop() {
 
     running = false;
 
-    wakeup();
+    notify_wake(wake_handle);
 
     /* deletion of thread not initiated within this thread */
     if (pthread_self() == tid) {
@@ -359,29 +610,6 @@ void cthread::stop() {
 
     state = STATE_IDLE;
 
-  } break;
-  default: {};
-  }
-}
-
-void cthread::wakeup() {
-  switch (state) {
-  case STATE_RUNNING: {
-    uint64_t c = 1;
-    if (write(event_fd, &c, sizeof(c)) < 0) {
-      switch (errno) {
-      case EAGAIN: {
-        // do nothing
-      } break;
-      case EINTR: {
-        // signal received
-      } break;
-      default: {
-        throw eSysCall("eSysCall", "write to event_fd", __FILE__, __FUNCTION__,
-                       __LINE__);
-      };
-      }
-    }
   } break;
   default: {};
   }
@@ -430,7 +658,8 @@ void *cthread::run_loop() {
         if (not running)
           goto out;
 
-        env->handle_timeout(*this, timer.get_timer_id());
+        timer.get_callback()->handle_timeout(
+            (void *)((intptr_t)timer.get_timer_id()));
       }
 
       if (not running)
@@ -443,25 +672,31 @@ void *cthread::run_loop() {
           if (not running)
             goto out;
 
-          if (events[i].data.fd == event_fd) {
+          VLOG(3) << __FUNCTION__ << ": fd=" << events[i].data.fd
+                  << " events=0x" << std::hex << events[i].events << std::dec;
 
-            if (not running) {
-              return &retval;
-            }
-
-            if (events[i].events & EPOLLIN) {
-              uint64_t c;
-              int rcode = read(event_fd, &c, sizeof(c));
-              (void)rcode;
-              env->handle_wakeup(*this);
-            }
-
-          } else {
-            if (events[i].events & EPOLLIN)
-              env->handle_read_event(*this, events[i].data.fd);
-            if (events[i].events & EPOLLOUT)
-              env->handle_write_event(*this, events[i].data.fd);
+          io_event *ioev = nullptr;
+          {
+            // XXX(toanju): check if can we get rid of the copy
+            AcquireReadLock lock(events_lock);
+            ioev = static_cast<io_event *>(events_reg[events[i].data.fd]);
+            if (ioev)
+              ioev = new io_event(*ioev);
+            else
+              continue;
           }
+
+          if (events[i].events & EPOLLIN) {
+            VLOG(1) << "call handle_read on fd=" << events[i].data.fd;
+            ioev->re->handle_read(events[i].data.fd, ioev->userdata_re);
+          }
+
+          if (events[i].events & EPOLLOUT) {
+            VLOG(1) << "call handle_write on fd=" << events[i].data.fd;
+            ioev->we->handle_write(events[i].data.fd, ioev->userdata_we);
+          }
+
+          delete ioev;
         }
       } else if (rc < 0) {
 
@@ -494,3 +729,5 @@ out:
 
   return &retval;
 }
+
+} // namespace rofl

--- a/src/rofl/common/cthread.hpp
+++ b/src/rofl/common/cthread.hpp
@@ -53,6 +53,8 @@ public:
 
 class cthread {
 public:
+  static const uint32_t ALL_TIMERS = -1;
+
   /**
    *
    */

--- a/src/rofl/common/cthread.hpp
+++ b/src/rofl/common/cthread.hpp
@@ -222,7 +222,8 @@ private:
 
   std::map<int, uint32_t> fds;     // set of registered file descriptors
   std::set<ctimer> ordered_timers; // ordered set of timers
-  int max_fds; // XXX(toanju): currently fixed to 1024, but should be read
+  int max_fds; // XXX(toanju): currently set constant to 1024, should be
+               // configureable and match the system specs though
   std::vector<event_base *> events_reg;
 
   enum thread_state_t {

--- a/src/rofl/common/cthread.hpp
+++ b/src/rofl/common/cthread.hpp
@@ -21,7 +21,6 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <unistd.h>
 
 #include <atomic>
 #include <cassert>
@@ -31,12 +30,17 @@
 #include <map>
 #include <set>
 
+#include "rofl/common/callbacks.hpp"
 #include "rofl/common/ctimer.hpp"
 #include "rofl/common/exception.hpp"
 #include "rofl/common/locking.hpp"
 
 namespace rofl {
 
+// forward declarations
+class event_base;
+
+// exceptions
 class eThreadBase : public exception {
 public:
   eThreadBase(const std::string &__arg) : exception(__arg){};
@@ -45,22 +49,6 @@ public:
 class eThreadNotFound : public eThreadBase {
 public:
   eThreadNotFound(const std::string &__arg) : eThreadBase(__arg){};
-};
-
-class cthread; // forward declaration
-
-class cthread_env {
-  friend class cthread;
-
-public:
-  cthread_env() {}
-  virtual ~cthread_env() {}
-
-protected:
-  virtual void handle_wakeup(cthread &thread) = 0;
-  virtual void handle_timeout(cthread &thread, uint32_t timer_id) = 0;
-  virtual void handle_read_event(cthread &thread, int fd) = 0;
-  virtual void handle_write_event(cthread &thread, int fd) = 0;
 };
 
 class cthread {
@@ -79,9 +67,8 @@ public:
   /**
    *
    */
-  cthread(cthread_env *env) : env(env), state(STATE_IDLE) { initialize(); };
+  cthread() : max_fds(1024), state(STATE_IDLE) { initialize(); };
 
-public:
   /**
    *
    */
@@ -90,22 +77,18 @@ public:
   /**
    * @brief	Wake up RX thread via rx pipe
    */
-  void wakeup();
+  int add_wakeup_observer(cthread_wakeup_event *cb, int *handle,
+                          void *userdata = nullptr);
 
-  /**
-   * @brief	Register file descriptor
-   */
-  void add_fd(int fd, bool exception = false, bool edge_triggered = true);
+  int remove_wakeup_observer(cthread_wakeup_event *cb, int handle);
 
-  /**
-   * @brief	Deregister file descriptor
-   */
-  void drop_fd(int fd, bool exception = false);
+  int notify_wake(int handle);
 
   /**
    * @brief	Add file descriptor to set of observed fds
    */
-  void add_read_fd(int fd, bool exception = true, bool edge_triggered = true);
+  void add_read_fd(int fd, cthread_read_event *cb, void *userdata,
+                   bool exception = true, bool edge_triggered = true);
 
   /**
    * @brief	Drop file descriptor from set of observed fds
@@ -115,14 +98,14 @@ public:
   /**
    * @brief	Add file descriptor to set of observed fds
    */
-  void add_write_fd(int fd, bool exception = true, bool edge_triggered = true);
+  void add_write_fd(int fd, cthread_write_event *cb, void *userdata,
+                    bool exception = true, bool edge_triggered = true);
 
   /**
    * @brief	Drop file descriptor from set of observed fds
    */
   void drop_write_fd(int fd, bool exception = true);
 
-public:
   /**
    *
    */
@@ -131,24 +114,24 @@ public:
   /**
    *
    */
-  bool add_timer(uint32_t timer_id, const ctimespec &tspec);
+  bool add_timer(cthread_timeout_event *e, uint32_t timer_id,
+                 const ctimespec &tspec);
 
   /**
    *
    */
-  const ctimer &get_timer(uint32_t timer_id) const;
+  const ctimer &get_timer(cthread_timeout_event *e, uint32_t timer_id) const;
 
   /**
    *
    */
-  bool drop_timer(uint32_t timer_id);
+  bool drop_timer(cthread_timeout_event *e, uint32_t timer_id);
 
   /**
    *
    */
-  bool has_timer(uint32_t timer_id) const;
+  bool has_timer(cthread_timeout_event *e, uint32_t timer_id) const;
 
-public:
   /**
    * @brief	Starts worker thread
    *
@@ -168,7 +151,6 @@ public:
    */
   void stop();
 
-public:
   friend std::ostream &operator<<(std::ostream &os, const cthread &thread) {
     os << "cthread, tid: " << &thread << std::endl;
     if (not thread.ordered_timers.empty()) {
@@ -184,6 +166,16 @@ public:
   };
 
 private:
+  /**
+   * @brief	Register file descriptor
+   */
+  void add_fd(int fd, bool exception = false, bool edge_triggered = true);
+
+  /**
+   * @brief	Deregister file descriptor
+   */
+  void drop_fd(int fd, bool exception = false);
+
   /**
    * @brief	Initialize data structures for running TX and RX threads
    *
@@ -219,22 +211,19 @@ private:
   // true: continue to run worker thread
   std::atomic_bool running;
 
-  // thread environment
-  cthread_env *env;
-
   // thread related variables
-  int event_fd;  // event fd for worker thread
   pthread_t tid; // pthread_t for worker thread
-  // bool				run_thread;	// true: continue to run
-  // worker
-  // thread
-  int retval; // worker thread return value
-  int epfd;   // worker thread epoll fd
+  int retval;    // worker thread return value
+  int epfd;      // worker thread epoll fd
+  int wake_handle;
 
-  crwlock tlock; // thread lock
+  crwlock tlock;       // thread lock
+  crwlock events_lock; // events lock
 
   std::map<int, uint32_t> fds;     // set of registered file descriptors
   std::set<ctimer> ordered_timers; // ordered set of timers
+  int max_fds; // XXX(toanju): currently fixed to 1024, but should be read
+  std::vector<event_base *> events_reg;
 
   enum thread_state_t {
     STATE_IDLE = 0,

--- a/src/rofl/common/cthread.hpp
+++ b/src/rofl/common/cthread.hpp
@@ -223,8 +223,6 @@ private:
   cthread_env *env;
 
   // thread related variables
-  static const int PIPE_READ_FD;
-  static const int PIPE_WRITE_FD;
   int event_fd;  // event fd for worker thread
   pthread_t tid; // pthread_t for worker thread
   // bool				run_thread;	// true: continue to run

--- a/src/rofl/common/ctimer.hpp
+++ b/src/rofl/common/ctimer.hpp
@@ -69,22 +69,20 @@ public:
   };
 
   bool operator<(const ctimer &t) const {
-    if (tspec == t.tspec) {
-      return timer_id < t.timer_id;
-    } else {
+    if (tspec != t.tspec)
       return tspec < t.tspec;
-    }
+    // tspec == t.tspec
+    if (timer_id != t.timer_id)
+      return timer_id < t.timer_id;
+    // timer_id == t.timer_id
+    return e < t.e;
   }
 
-  /**
-   *
-   */
-  uint32_t get_timer_id() const { return timer_id; };
+  uint32_t get_timer_id() const { return timer_id; }
 
-  /**
-   *
-   */
-  const ctimespec &get_tspec() const { return tspec; };
+  const ctimespec &get_tspec() const { return tspec; }
+
+  const ctimespec &get_created() const { return created; }
 
   cthread_timeout_event *get_callback() { return e; }
 
@@ -95,14 +93,14 @@ public:
    */
   void expire_in(time_t tv_sec = 0, long tv_nsec = 0) {
     tspec.expire_in(tv_sec, tv_nsec);
-  };
+  }
 
   /**
    *
    */
   int get_relative_timeout() const {
     return get_tspec().get_relative_timeout();
-  };
+  }
 
   /**
    *
@@ -110,11 +108,12 @@ public:
   friend std::ostream &operator<<(std::ostream &os, const ctimer &ts) {
     os << "<ctimer: >";
     return os;
-  };
+  }
 
 private:
   uint32_t timer_id;
   ctimespec tspec;
+  ctimespec created;
   cthread_timeout_event *e;
 };
 

--- a/src/rofl/common/locking.hpp
+++ b/src/rofl/common/locking.hpp
@@ -31,7 +31,7 @@ public:
     }
   };
   crwlock() {
-    if (pthread_rwlock_init(&rwlock, NULL) < 0) {
+    if (pthread_rwlock_init(&rwlock, nullptr) < 0) {
       throw eSysCall("pthread_rwlock_init syscall failed")
           .set_func(__FUNCTION__)
           .set_line(__LINE__);

--- a/src/rofl/common/openflow/cofaggrstats.h
+++ b/src/rofl/common/openflow/cofaggrstats.h
@@ -33,7 +33,7 @@ public:
    *
    */
   cofaggr_stats_request(uint8_t of_version = openflow::OFP_VERSION_UNKNOWN,
-                        uint8_t *buf = (uint8_t *)0, size_t buflen = 0)
+                        uint8_t *buf = nullptr, size_t buflen = 0)
       : of_version(of_version), match(of_version), table_id(0), out_port(0),
         out_group(0), cookie(0), cookie_mask(0) {
     if ((buflen == 0) || (nullptr == buf)) {
@@ -277,7 +277,7 @@ public:
   /**
    *
    */
-  cofaggr_stats_reply(uint8_t of_version = 0, uint8_t *buf = (uint8_t *)0,
+  cofaggr_stats_reply(uint8_t of_version = 0, uint8_t *buf = nullptr,
                       size_t buflen = 0)
       : of_version(of_version), packet_count(0), byte_count(0), flow_count(0) {
     if ((buflen == 0) || (nullptr == buf)) {

--- a/src/rofl/common/openflow/cofflowstats.h
+++ b/src/rofl/common/openflow/cofflowstats.h
@@ -50,7 +50,7 @@ public:
    */
   cofflow_stats_request(
       uint8_t of_version = rofl::openflow::OFP_VERSION_UNKNOWN,
-      uint8_t *buf = (uint8_t *)0, size_t buflen = 0)
+      uint8_t *buf = nullptr, size_t buflen = 0)
       : of_version(of_version), match(of_version), table_id(0xff),
         out_port(rofl::openflow::OFPP_ANY), out_group(rofl::openflow::OFPG_ANY),
         cookie(0), cookie_mask(0) {
@@ -275,7 +275,7 @@ public:
   /**
    *
    */
-  cofflow_stats_reply(uint8_t of_version = 0, uint8_t *buf = (uint8_t *)0,
+  cofflow_stats_reply(uint8_t of_version = 0, uint8_t *buf = nullptr,
                       size_t buflen = 0)
       : of_version(of_version), table_id(0), duration_sec(0), duration_nsec(0),
         priority(0), idle_timeout(0), hard_timeout(0), flags(0), cookie(0),

--- a/src/rofl/common/openflow/cofflowstatsarray.h
+++ b/src/rofl/common/openflow/cofflowstatsarray.h
@@ -222,7 +222,7 @@ public:
   /**
    *
    */
-  void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/cofgroupdescstatsarray.h
+++ b/src/rofl/common/openflow/cofgroupdescstatsarray.h
@@ -199,7 +199,7 @@ public:
   /**
    *
    */
-  void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/cofgroupfeaturesstats.h
+++ b/src/rofl/common/openflow/cofgroupfeaturesstats.h
@@ -33,7 +33,7 @@ public:
    *
    */
   cofgroup_features_stats_reply(uint8_t of_version = 0,
-                                uint8_t *buf = (uint8_t *)0, size_t buflen = 0)
+                                uint8_t *buf = nullptr, size_t buflen = 0)
       : of_version(of_version), types(0), capabilities(0) {
     max_groups.resize(4);
     actions.resize(4);

--- a/src/rofl/common/openflow/cofgroupstatsarray.h
+++ b/src/rofl/common/openflow/cofgroupstatsarray.h
@@ -211,7 +211,7 @@ public:
   /**
    *
    */
-  void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/cofhelloelemversionbitmap.h
+++ b/src/rofl/common/openflow/cofhelloelemversionbitmap.h
@@ -16,7 +16,7 @@
 namespace rofl {
 namespace openflow {
 
-class cofhello_elem_versionbitmap : public cofhello_elem {
+class cofhello_elem_versionbitmap final : public cofhello_elem {
   std::vector<uint32_t> bitmaps;
 
   union {

--- a/src/rofl/common/openflow/cofmatch.h
+++ b/src/rofl/common/openflow/cofmatch.h
@@ -7,7 +7,6 @@
 
 #include <bitset>
 #include <endian.h>
-#include <endian.h>
 #include <stdio.h>
 #include <string.h>
 #include <string>
@@ -15,7 +14,6 @@
 #include "../endian_conversion.h"
 #endif
 
-#include "rofl/common/caddress.h"
 #include "rofl/common/caddress.h"
 #include "rofl/common/cmemory.h"
 #include "rofl/common/exception.hpp"

--- a/src/rofl/common/openflow/cofmeterconfig.h
+++ b/src/rofl/common/openflow/cofmeterconfig.h
@@ -47,7 +47,7 @@ public:
    */
   cofmeter_config_request(
       uint8_t of_version = rofl::openflow::OFP_VERSION_UNKNOWN,
-      uint8_t *buf = (uint8_t *)0, size_t buflen = 0)
+      uint8_t *buf = nullptr, size_t buflen = 0)
       : of_version(of_version), meter_id(0) {
     if ((buflen == 0) || (nullptr == buf)) {
       return;
@@ -155,7 +155,7 @@ public:
    */
   cofmeter_config_reply(
       uint8_t of_version = rofl::openflow::OFP_VERSION_UNKNOWN,
-      uint8_t *buf = (uint8_t *)0, size_t buflen = 0)
+      uint8_t *buf = nullptr, size_t buflen = 0)
       : of_version(of_version), flags(0), meter_id(0), mbands(of_version) {
     if ((buflen == 0) || (nullptr == buf)) {
       return;

--- a/src/rofl/common/openflow/cofmeterconfigarray.h
+++ b/src/rofl/common/openflow/cofmeterconfigarray.h
@@ -210,7 +210,7 @@ public:
   /**
    *
    */
-  void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/cofmeterfeatures.h
+++ b/src/rofl/common/openflow/cofmeterfeatures.h
@@ -24,7 +24,7 @@ public:
   /**
    *
    */
-  cofmeter_features_reply(uint8_t of_version = 0, uint8_t *buf = (uint8_t *)0,
+  cofmeter_features_reply(uint8_t of_version = 0, uint8_t *buf = nullptr,
                           size_t buflen = 0);
 
   /**

--- a/src/rofl/common/openflow/cofmeterstats.h
+++ b/src/rofl/common/openflow/cofmeterstats.h
@@ -47,7 +47,7 @@ public:
    */
   cofmeter_stats_request(
       uint8_t of_version = rofl::openflow::OFP_VERSION_UNKNOWN,
-      uint8_t *buf = (uint8_t *)0, size_t buflen = 0)
+      uint8_t *buf = nullptr, size_t buflen = 0)
       : of_version(of_version), meter_id(0) {
     if ((buflen == 0) || (nullptr == buf)) {
       return;
@@ -154,7 +154,7 @@ public:
    *
    */
   cofmeter_stats_reply(uint8_t of_version = rofl::openflow::OFP_VERSION_UNKNOWN,
-                       uint8_t *buf = (uint8_t *)0, size_t buflen = 0)
+                       uint8_t *buf = nullptr, size_t buflen = 0)
       : of_version(of_version), meter_id(0), flow_count(0), packet_in_count(0),
         byte_in_count(0), duration_sec(0), duration_nsec(0),
         mbstats(of_version) {

--- a/src/rofl/common/openflow/cofmeterstatsarray.h
+++ b/src/rofl/common/openflow/cofmeterstatsarray.h
@@ -205,7 +205,7 @@ public:
   /**
    *
    */
-  void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/cofportstats.h
+++ b/src/rofl/common/openflow/cofportstats.h
@@ -47,7 +47,7 @@ public:
    */
   cofport_stats_request(
       uint8_t of_version = rofl::openflow::OFP_VERSION_UNKNOWN,
-      uint8_t *buf = (uint8_t *)0, size_t buflen = 0)
+      uint8_t *buf = nullptr, size_t buflen = 0)
       : of_version(of_version), port_no(rofl::openflow13::OFPP_ALL) {
     if ((buflen == 0) || (nullptr == buf)) {
       return;
@@ -147,7 +147,7 @@ public:
    *
    */
   cofport_stats_reply(uint8_t of_version = rofl::openflow::OFP_VERSION_UNKNOWN,
-                      uint8_t *buf = (uint8_t *)0, size_t buflen = 0)
+                      uint8_t *buf = nullptr, size_t buflen = 0)
       : of_version(of_version), port_no(0), rx_packets(0), tx_packets(0),
         rx_bytes(0), tx_bytes(0), rx_dropped(0), tx_dropped(0), rx_errors(0),
         tx_errors(0), rx_frame_err(0), rx_over_err(0), rx_crc_err(0),

--- a/src/rofl/common/openflow/cofportstatsarray.h
+++ b/src/rofl/common/openflow/cofportstatsarray.h
@@ -210,7 +210,7 @@ public:
   /**
    *
    */
-  void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/cofqueuestatsarray.h
+++ b/src/rofl/common/openflow/cofqueuestatsarray.h
@@ -245,7 +245,7 @@ public:
   /**
    *
    */
-  void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/coftablestatsarray.h
+++ b/src/rofl/common/openflow/coftablestatsarray.h
@@ -211,7 +211,7 @@ public:
   /**
    *
    */
-  void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg.h
+++ b/src/rofl/common/openflow/messages/cofmsg.h
@@ -64,7 +64,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_aggr_stats.h
+++ b/src/rofl/common/openflow/messages/cofmsg_aggr_stats.h
@@ -55,7 +55,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *
@@ -129,7 +129,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_async_config.h
+++ b/src/rofl/common/openflow/messages/cofmsg_async_config.h
@@ -54,7 +54,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *
@@ -114,7 +114,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *
@@ -190,7 +190,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_barrier.h
+++ b/src/rofl/common/openflow/messages/cofmsg_barrier.h
@@ -63,7 +63,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *
@@ -150,7 +150,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_config.h
+++ b/src/rofl/common/openflow/messages/cofmsg_config.h
@@ -106,7 +106,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *
@@ -239,7 +239,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_desc_stats.h
+++ b/src/rofl/common/openflow/messages/cofmsg_desc_stats.h
@@ -54,7 +54,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *
@@ -113,7 +113,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_echo.h
+++ b/src/rofl/common/openflow/messages/cofmsg_echo.h
@@ -57,7 +57,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *
@@ -137,7 +137,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_error.h
+++ b/src/rofl/common/openflow/messages/cofmsg_error.h
@@ -61,7 +61,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_experimenter.h
+++ b/src/rofl/common/openflow/messages/cofmsg_experimenter.h
@@ -29,7 +29,7 @@ public:
    */
   cofmsg_experimenter(uint8_t version = 0, uint32_t xid = 0,
                       uint32_t exp_id = 0, uint32_t exp_type = 0,
-                      uint8_t *data = (uint8_t *)0, size_t datalen = 0)
+                      uint8_t *data = nullptr, size_t datalen = 0)
       : cofmsg(version, rofl::openflow::OFPT_EXPERIMENTER, xid), exp_id(exp_id),
         exp_type(exp_type), body(data, datalen){};
 
@@ -59,7 +59,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_experimenter_stats.h
+++ b/src/rofl/common/openflow/messages/cofmsg_experimenter_stats.h
@@ -58,7 +58,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *
@@ -168,7 +168,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_features.h
+++ b/src/rofl/common/openflow/messages/cofmsg_features.h
@@ -119,7 +119,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_flow_mod.h
+++ b/src/rofl/common/openflow/messages/cofmsg_flow_mod.h
@@ -55,7 +55,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_flow_removed.h
+++ b/src/rofl/common/openflow/messages/cofmsg_flow_removed.h
@@ -77,7 +77,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_flow_stats.h
+++ b/src/rofl/common/openflow/messages/cofmsg_flow_stats.h
@@ -57,7 +57,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *
@@ -132,7 +132,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_group_desc_stats.h
+++ b/src/rofl/common/openflow/messages/cofmsg_group_desc_stats.h
@@ -56,7 +56,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *
@@ -117,7 +117,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_group_features_stats.h
+++ b/src/rofl/common/openflow/messages/cofmsg_group_features_stats.h
@@ -57,7 +57,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *
@@ -119,7 +119,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_group_stats.h
+++ b/src/rofl/common/openflow/messages/cofmsg_group_stats.h
@@ -57,7 +57,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *
@@ -136,7 +136,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_hello.h
+++ b/src/rofl/common/openflow/messages/cofmsg_hello.h
@@ -59,7 +59,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_meter_config_stats.h
+++ b/src/rofl/common/openflow/messages/cofmsg_meter_config_stats.h
@@ -67,7 +67,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *
@@ -147,7 +147,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_meter_features_stats.h
+++ b/src/rofl/common/openflow/messages/cofmsg_meter_features_stats.h
@@ -60,7 +60,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *
@@ -122,7 +122,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_meter_mod.h
+++ b/src/rofl/common/openflow/messages/cofmsg_meter_mod.h
@@ -57,7 +57,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_meter_stats.h
+++ b/src/rofl/common/openflow/messages/cofmsg_meter_stats.h
@@ -66,7 +66,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *
@@ -145,7 +145,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_packet_in.h
+++ b/src/rofl/common/openflow/messages/cofmsg_packet_in.h
@@ -33,7 +33,7 @@ public:
       uint16_t total_len = 0, uint8_t reason = 0, uint8_t table_id = 0,
       uint64_t cookie = 0, uint16_t in_port = 0,
       const rofl::openflow::cofmatch &match = rofl::openflow::cofmatch(),
-      uint8_t *data = (uint8_t *)0, size_t datalen = 0)
+      uint8_t *data = nullptr, size_t datalen = 0)
       : cofmsg(version, rofl::openflow::OFPT_PACKET_IN, xid),
         buffer_id(buffer_id), total_len(total_len), in_port(in_port),
         reason(reason), table_id(table_id), cookie(cookie), match(match),
@@ -73,7 +73,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_packet_out.h
+++ b/src/rofl/common/openflow/messages/cofmsg_packet_out.h
@@ -32,7 +32,7 @@ public:
       uint8_t version = 0, uint32_t xid = 0, uint32_t buffer_id = 0,
       uint32_t in_port = 0,
       const rofl::openflow::cofactions &actions = rofl::openflow::cofactions(),
-      uint8_t *data = (uint8_t *)0, size_t datalen = 0)
+      uint8_t *data = nullptr, size_t datalen = 0)
       : cofmsg(version, rofl::openflow::OFPT_PACKET_OUT, xid),
         buffer_id(buffer_id), in_port(in_port), actions(actions),
         packet(data, datalen){};
@@ -65,7 +65,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_port_desc_stats.h
+++ b/src/rofl/common/openflow/messages/cofmsg_port_desc_stats.h
@@ -56,7 +56,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *
@@ -116,7 +116,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_port_mod.h
+++ b/src/rofl/common/openflow/messages/cofmsg_port_mod.h
@@ -57,7 +57,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_port_stats.h
+++ b/src/rofl/common/openflow/messages/cofmsg_port_stats.h
@@ -56,7 +56,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *
@@ -136,7 +136,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_port_status.h
+++ b/src/rofl/common/openflow/messages/cofmsg_port_status.h
@@ -62,7 +62,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_queue_get_config.h
+++ b/src/rofl/common/openflow/messages/cofmsg_queue_get_config.h
@@ -57,7 +57,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *
@@ -133,7 +133,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_queue_stats.h
+++ b/src/rofl/common/openflow/messages/cofmsg_queue_stats.h
@@ -57,7 +57,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *
@@ -136,7 +136,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_role.h
+++ b/src/rofl/common/openflow/messages/cofmsg_role.h
@@ -55,7 +55,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *
@@ -129,7 +129,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_stats.h
+++ b/src/rofl/common/openflow/messages/cofmsg_stats.h
@@ -50,7 +50,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *
@@ -152,7 +152,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_table_features_stats.h
+++ b/src/rofl/common/openflow/messages/cofmsg_table_features_stats.h
@@ -58,7 +58,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *
@@ -134,7 +134,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_table_mod.h
+++ b/src/rofl/common/openflow/messages/cofmsg_table_mod.h
@@ -53,7 +53,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/messages/cofmsg_table_stats.h
+++ b/src/rofl/common/openflow/messages/cofmsg_table_stats.h
@@ -56,7 +56,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *
@@ -116,7 +116,7 @@ public:
   /**
    *
    */
-  virtual void pack(uint8_t *buf = (uint8_t *)0, size_t buflen = 0);
+  virtual void pack(uint8_t *buf = nullptr, size_t buflen = 0);
 
   /**
    *

--- a/src/rofl/common/openflow/openflow10.h
+++ b/src/rofl/common/openflow/openflow10.h
@@ -785,7 +785,7 @@ OFP_ASSERT(sizeof(struct ofp_stats_reply) == 12);
 
 #define DESC_STR_LEN 256
 #define SERIAL_NUM_LEN 32
-/* Body of reply to OFPST_DESC request.  Each entry is a NULL-terminated
+/* Body of reply to OFPST_DESC request.  Each entry is a nullptr-terminated
  * ASCII string. */
 struct ofp_desc_stats {
   char mfr_desc[DESC_STR_LEN];     /* Manufacturer description. */

--- a/src/rofl/common/openflow/openflow12.h
+++ b/src/rofl/common/openflow/openflow12.h
@@ -1349,7 +1349,7 @@ OFP_ASSERT(sizeof(struct ofp_stats_reply) == 16);
 
 #define DESC_STR_LEN 256
 #define SERIAL_NUM_LEN 32
-/* Body of reply to OFPST_DESC request.  Each entry is a NULL-terminated
+/* Body of reply to OFPST_DESC request.  Each entry is a nullptr-terminated
  * ASCII string. */
 struct ofp_desc_stats {
   char mfr_desc[DESC_STR_LEN];     /* Manufacturer description. */

--- a/src/rofl/common/openflow/openflow13.h
+++ b/src/rofl/common/openflow/openflow13.h
@@ -1228,7 +1228,7 @@ enum ofp_multipart_types {
  * 7.3.5.1 Description
  */
 
-/* Body of reply to OFPMP_DESC request. Each entry is a NULL-terminated
+/* Body of reply to OFPMP_DESC request. Each entry is a nullptr-terminated
 * ASCII string. */
 struct ofp_desc {
   char mfr_desc[DESC_STR_LEN];     /* Manufacturer description. */

--- a/src/rofl/common/openflow/openflow14.h
+++ b/src/rofl/common/openflow/openflow14.h
@@ -2155,7 +2155,7 @@ struct ofp_multipart_reply {
 };
 OFP_ASSERT(sizeof(struct ofp_multipart_reply) == 16);
 
-/* Body of reply to OFPMP_DESC request.  Each entry is a NULL-terminated
+/* Body of reply to OFPMP_DESC request.  Each entry is a nullptr-terminated
  * ASCII string. */
 struct ofp_desc {
   char mfr_desc[DESC_STR_LEN];     /* Manufacturer description. */

--- a/test/rofl/common/crofbase/Makefile.am
+++ b/test/rofl/common/crofbase/Makefile.am
@@ -12,5 +12,6 @@ crofbasetest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lpthread -lcppun
 
 #Tests
 
+AM_TESTS_ENVIRONMENT = GLOG_logtostderr=1
 check_PROGRAMS= crofbasetest
 TESTS = crofbasetest

--- a/test/rofl/common/crofbase/crofbasetest.cpp
+++ b/test/rofl/common/crofbase/crofbasetest.cpp
@@ -29,9 +29,9 @@ void crofbasetest::test() {
     ts.tv_sec = 1;
     ts.tv_nsec = 0;
     pselect(0, NULL, NULL, NULL, &ts, NULL);
-    std::cerr << "#";
+    LOG(INFO) << "#";
   }
-  std::cerr << std::endl;
+  LOG(INFO) << std::endl;
 
   datapath.set_ctl(datapath.get_ctlid()).set_conn(0).close();
 
@@ -83,7 +83,7 @@ void cdatapath::test_start() {
 }
 
 void ccontroller::handle_dpt_open(rofl::crofdpt &dpt) {
-  std::cerr << ">>> XXX dpt connected: " << std::endl;
+  LOG(INFO) << ">>> XXX dpt connected: " << std::endl;
 
   dptid = dpt.get_dptid();
 
@@ -91,13 +91,13 @@ void ccontroller::handle_dpt_open(rofl::crofdpt &dpt) {
 }
 
 void cdatapath::handle_ctl_open(rofl::crofctl &ctl) {
-  std::cerr << ">>> XXX ctl connected: " << std::endl;
+  LOG(INFO) << ">>> XXX ctl connected: " << std::endl;
 }
 
 void cdatapath::handle_features_request(
     rofl::crofctl &ctl, const rofl::cauxid &auxid,
     rofl::openflow::cofmsg_features_request &msg) {
-  std::cerr << ">>> XXX -Features-Request- rcvd" << std::endl << auxid;
+  LOG(INFO) << ">>> XXX -Features-Request- rcvd" << std::endl << auxid;
 
   ctl.send_features_reply(auxid, msg.get_xid(), dpid, n_buffers, n_tables,
                           capabilities,
@@ -107,14 +107,14 @@ void cdatapath::handle_features_request(
 void ccontroller::handle_features_reply(
     rofl::crofdpt &dpt, const rofl::cauxid &auxid,
     rofl::openflow::cofmsg_features_reply &msg) {
-  std::cerr << ">>> XXX -Features-Reply- rcvd" << std::endl;
+  LOG(INFO) << ">>> XXX -Features-Reply- rcvd" << std::endl;
   dpt.send_get_config_request(auxid);
 }
 
 void cdatapath::handle_get_config_request(
     rofl::crofctl &ctl, const rofl::cauxid &auxid,
     rofl::openflow::cofmsg_get_config_request &msg) {
-  std::cerr << ">>> XXX -Get-Config-Request- rcvd" << std::endl;
+  LOG(INFO) << ">>> XXX -Get-Config-Request- rcvd" << std::endl;
 
   ctl.send_get_config_reply(auxid, msg.get_xid(), flags, miss_send_len);
 }
@@ -122,7 +122,7 @@ void cdatapath::handle_get_config_request(
 void cdatapath::handle_barrier_request(
     rofl::crofctl &ctl, const rofl::cauxid &auxid,
     rofl::openflow::cofmsg_barrier_request &msg) {
-  std::cerr << ">>> XXX -Barrier-Request- rcvd" << std::endl;
+  LOG(INFO) << ">>> XXX -Barrier-Request- rcvd" << std::endl;
 
   /* do not send barrier-reply back => wait for request timeout at controller */
 }
@@ -130,7 +130,7 @@ void cdatapath::handle_barrier_request(
 void ccontroller::handle_get_config_reply(
     rofl::crofdpt &dpt, const rofl::cauxid &auxid,
     rofl::openflow::cofmsg_get_config_reply &msg) {
-  std::cerr << ">>> XXX -Get-Config-Reply- rcvd" << std::endl;
+  LOG(INFO) << ">>> XXX -Get-Config-Reply- rcvd" << std::endl;
 
   uint16_t flags = 0;
   dpt.send_table_features_stats_request(auxid, flags);
@@ -139,7 +139,7 @@ void ccontroller::handle_get_config_reply(
 void cdatapath::handle_table_features_stats_request(
     rofl::crofctl &ctl, const rofl::cauxid &auxid,
     rofl::openflow::cofmsg_table_features_stats_request &msg) {
-  std::cerr << ">>> XXX -Table-Features-Stats-Request- rcvd" << std::endl;
+  LOG(INFO) << ">>> XXX -Table-Features-Stats-Request- rcvd" << std::endl;
 
   ctl.send_table_features_stats_reply(auxid, msg.get_xid(), tables, 0);
 }
@@ -147,7 +147,7 @@ void cdatapath::handle_table_features_stats_request(
 void ccontroller::handle_table_features_stats_reply(
     rofl::crofdpt &dpt, const rofl::cauxid &auxid,
     rofl::openflow::cofmsg_table_features_stats_reply &msg) {
-  std::cerr << ">>> XXX -Table-Features-Stats-Reply- rcvd" << std::endl;
+  LOG(INFO) << ">>> XXX -Table-Features-Stats-Reply- rcvd" << std::endl;
 
   uint16_t flags = 0;
   dpt.send_port_desc_stats_request(auxid, flags);
@@ -156,7 +156,7 @@ void ccontroller::handle_table_features_stats_reply(
 void cdatapath::handle_port_desc_stats_request(
     rofl::crofctl &ctl, const rofl::cauxid &auxid,
     rofl::openflow::cofmsg_port_desc_stats_request &msg) {
-  std::cerr << ">>> XXX -Port-Desc-Stats-Request- rcvd" << std::endl;
+  LOG(INFO) << ">>> XXX -Port-Desc-Stats-Request- rcvd" << std::endl;
 
   ctl.send_port_desc_stats_reply(auxid, msg.get_xid(), ports, 0);
 }
@@ -164,7 +164,7 @@ void cdatapath::handle_port_desc_stats_request(
 void ccontroller::handle_port_desc_stats_reply(
     rofl::crofdpt &dpt, const rofl::cauxid &auxid,
     rofl::openflow::cofmsg_port_desc_stats_reply &msg) {
-  std::cerr << ">>> XXX -Port-Desc-Stats-Reply- rcvd" << std::endl;
+  LOG(INFO) << ">>> XXX -Port-Desc-Stats-Reply- rcvd" << std::endl;
 
   for (int i = 0; i < 4; i++) {
     dpt.send_barrier_request(auxid);
@@ -174,14 +174,14 @@ void ccontroller::handle_port_desc_stats_reply(
 void ccontroller::handle_barrier_reply(
     rofl::crofdpt &dpt, const rofl::cauxid &auxid,
     rofl::openflow::cofmsg_barrier_reply &msg) {
-  std::cerr << ">>> XXX -Barrier-Reply- rcvd" << std::endl;
+  LOG(INFO) << ">>> XXX -Barrier-Reply- rcvd" << std::endl;
 
   CPPUNIT_ASSERT(false);
 }
 
 void ccontroller::handle_barrier_reply_timeout(rofl::crofdpt &dpt,
                                                uint32_t xid) {
-  std::cerr << ">>> XXX -Barrier-Reply-Timeout- rcvd" << std::endl;
+  LOG(INFO) << ">>> XXX -Barrier-Reply-Timeout- rcvd" << std::endl;
 
   __keep_running = false;
 }

--- a/test/rofl/common/crofbase/crofbasetest.cpp
+++ b/test/rofl/common/crofbase/crofbasetest.cpp
@@ -28,7 +28,7 @@ void crofbasetest::test() {
     struct timespec ts;
     ts.tv_sec = 1;
     ts.tv_nsec = 0;
-    pselect(0, NULL, NULL, NULL, &ts, NULL);
+    pselect(0, nullptr, nullptr, nullptr, &ts, nullptr);
     LOG(INFO) << "#";
   }
 

--- a/test/rofl/common/crofbase/crofbasetest.cpp
+++ b/test/rofl/common/crofbase/crofbasetest.cpp
@@ -31,16 +31,12 @@ void crofbasetest::test() {
     pselect(0, NULL, NULL, NULL, &ts, NULL);
     LOG(INFO) << "#";
   }
-  LOG(INFO) << std::endl;
 
   datapath.set_ctl(datapath.get_ctlid()).set_conn(0).close();
 
-  sleep(2);
+  sleep(10); // enough time to safely delete everything to exit without
+             // complains of asan
 }
-
-void crofbasetest::handle_wakeup(rofl::cthread &thread) {}
-
-void crofbasetest::handle_timeout(rofl::cthread &thread, uint32_t timer_id) {}
 
 ccontroller::~ccontroller() {}
 

--- a/test/rofl/common/crofbase/crofbasetest.hpp
+++ b/test/rofl/common/crofbase/crofbasetest.hpp
@@ -142,35 +142,22 @@ private:
   rofl::openflow::cofports ports;
 };
 
-class crofbasetest : public CppUnit::TestFixture, public rofl::cthread_env {
+class crofbasetest : public CppUnit::TestFixture {
 
   CPPUNIT_TEST_SUITE(crofbasetest);
   CPPUNIT_TEST(test);
   CPPUNIT_TEST_SUITE_END();
 
-public:
-  void setUp();
-  void tearDown();
-
-public:
-  void test();
-
-private:
-  virtual void handle_wakeup(rofl::cthread &thread);
-
-  virtual void handle_timeout(rofl::cthread &thread, uint32_t timer_id);
-
-  virtual void handle_read_event(rofl::cthread &thread, int fd){};
-  virtual void handle_write_event(rofl::cthread &thread, int fd){};
-
-private:
   // test controller
   ccontroller controller;
 
   // test datapath
   cdatapath datapath;
 
-private:
+public:
+  void setUp();
+  void tearDown();
+  void test();
 };
 
 #endif /* TEST_USG_UNIT_TEST_HPP_ */

--- a/test/rofl/common/crofbase/crofbasetest.hpp
+++ b/test/rofl/common/crofbase/crofbasetest.hpp
@@ -73,7 +73,7 @@ private:
   rofl::cdptid dptid;
 
   // keep test running
-  bool __keep_running;
+  std::atomic_bool __keep_running;
 };
 
 class cdatapath : public rofl::crofbase {

--- a/test/rofl/common/crofbase/unittest.cpp
+++ b/test/rofl/common/crofbase/unittest.cpp
@@ -8,8 +8,11 @@
 #include <cppunit/extensions/TestFactoryRegistry.h>
 #include <cppunit/ui/text/TestRunner.h>
 #include <stdlib.h>
+#include <glog/logging.h>
 
 int main(int argc, char **argv) {
+  google::InitGoogleLogging(argv[0]);
+
   CppUnit::TextUi::TestRunner runner;
   CppUnit::TestFactoryRegistry &registry =
       CppUnit::TestFactoryRegistry::getRegistry();

--- a/test/rofl/common/crofbase/unittest.cpp
+++ b/test/rofl/common/crofbase/unittest.cpp
@@ -7,8 +7,8 @@
 
 #include <cppunit/extensions/TestFactoryRegistry.h>
 #include <cppunit/ui/text/TestRunner.h>
-#include <stdlib.h>
 #include <glog/logging.h>
+#include <stdlib.h>
 
 int main(int argc, char **argv) {
   google::InitGoogleLogging(argv[0]);

--- a/test/rofl/common/crofchan/Makefile.am
+++ b/test/rofl/common/crofchan/Makefile.am
@@ -12,5 +12,6 @@ crofchantest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 
+AM_TESTS_ENVIRONMENT = GLOG_logtostderr=1
 check_PROGRAMS= crofchantest
 TESTS = crofchantest

--- a/test/rofl/common/crofchan/Makefile.am
+++ b/test/rofl/common/crofchan/Makefile.am
@@ -12,6 +12,6 @@ crofchantest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 
-AM_TESTS_ENVIRONMENT = GLOG_logtostderr=1
+AM_TESTS_ENVIRONMENT = GLOG_logtostderr=1 GLOG_v=2
 check_PROGRAMS= crofchantest
 TESTS = crofchantest

--- a/test/rofl/common/crofchan/crofchantest.cpp
+++ b/test/rofl/common/crofchan/crofchantest.cpp
@@ -103,7 +103,7 @@ void crofchantest::test_connections() {
     struct timespec ts;
     ts.tv_sec = 1;
     ts.tv_nsec = 0;
-    pselect(0, NULL, NULL, NULL, &ts, NULL);
+    pselect(0, nullptr, nullptr, nullptr, &ts, nullptr);
     LOG(INFO) << ".";
     if (num_of_ctl_established == num_of_conns) {
       break;
@@ -199,7 +199,7 @@ void crofchantest::test_congestion() {
     struct timespec ts;
     ts.tv_sec = 1;
     ts.tv_nsec = 0;
-    pselect(0, NULL, NULL, NULL, &ts, NULL);
+    pselect(0, nullptr, nullptr, nullptr, &ts, nullptr);
   }
 
   LOG(INFO) << ">>>>>TERMINATING(listen): num_of_ctl_established = "

--- a/test/rofl/common/crofchan/crofchantest.cpp
+++ b/test/rofl/common/crofchan/crofchantest.cpp
@@ -53,6 +53,7 @@ void crofchantest::setUp() {
 
 void crofchantest::tearDown() {
   LOG(INFO) << __FUNCTION__;
+  tchan1->drop_timer(this, rofl::cthread::ALL_TIMERS);
   tchan1->stop();
   tchan2->stop();
 

--- a/test/rofl/common/crofchan/crofchantest.cpp
+++ b/test/rofl/common/crofchan/crofchantest.cpp
@@ -9,6 +9,7 @@
 
 #include <cppunit/extensions/TestFactoryRegistry.h>
 #include <cppunit/ui/text/TestRunner.h>
+#include <glog/logging.h>
 
 #include "crofchantest.hpp"
 
@@ -53,12 +54,12 @@ void crofchantest::test_connections() {
       listening_port = rand.uint16();
     } while ((listening_port < 10000) || (listening_port > 49000));
     try {
-      std::cerr << "trying listening port=" << (int)listening_port << std::endl;
+      LOG(INFO) << "trying listening port=" << (int)listening_port << std::endl;
       baddr = rofl::csockaddr(rofl::caddress_in4("127.0.0.1"), listening_port);
       /* try to bind address first */
       rofsock->set_backlog(num_of_conns);
       rofsock->set_baddr(baddr).listen();
-      std::cerr << "binding to " << baddr.str() << std::endl;
+      LOG(INFO) << "binding to " << baddr.str() << std::endl;
       lookup_idle_port = false;
     } catch (rofl::eSysCall &e) {
       /* port in use, try another one */
@@ -73,7 +74,7 @@ void crofchantest::test_connections() {
 
     num_of_dpt_established++;
 
-    std::cerr << "auxid(" << i << "): connecting to " << baddr.str()
+    LOG(INFO) << "auxid(" << i << "): connecting to " << baddr.str()
               << std::endl;
   }
 
@@ -82,32 +83,32 @@ void crofchantest::test_connections() {
     ts.tv_sec = 2;
     ts.tv_nsec = 0;
     pselect(0, NULL, NULL, NULL, &ts, NULL);
-    std::cerr << ".";
+    LOG(INFO) << ".";
     if (num_of_ctl_established == num_of_conns) {
       break;
     }
   }
   sleep(2);
 
-  std::cerr << ">>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<" << std::endl;
-  std::cerr << ">>>          TERMINATING          <<<" << std::endl;
-  std::cerr << ">>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<" << std::endl;
+  LOG(INFO) << ">>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<" << std::endl
+            << ">>>          TERMINATING          <<<" << std::endl
+            << ">>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<" << std::endl
 
-  std::cerr << ">>>>>>>>>>>>> listen <<<<<<<<<<<<<<" << std::endl;
+            << ">>>>>>>>>>>>> listen <<<<<<<<<<<<<<" << std::endl
 
-  std::cerr << "num_of_ctl_established = " << num_of_ctl_established
-            << std::endl;
-  std::cerr << "num_of_dpt_established = " << num_of_dpt_established
-            << std::endl;
-  std::cerr << "num_of_conns = " << num_of_conns << std::endl;
-  std::cerr << "num_of_accepts = " << num_of_accepts << std::endl;
-  std::cerr << "channel1.size() = " << channel1->keys().size() << std::endl;
-  std::cerr << "channel2.size() = " << channel2->keys().size() << std::endl;
+            << "num_of_ctl_established = " << num_of_ctl_established
+            << std::endl
+            << "num_of_dpt_established = " << num_of_dpt_established
+            << std::endl
+            << "num_of_conns = " << num_of_conns << std::endl
+            << "num_of_accepts = " << num_of_accepts << std::endl
+            << "channel1.size() = " << channel1->keys().size() << std::endl
+            << "channel2.size() = " << channel2->keys().size() << std::endl;
   CPPUNIT_ASSERT(channel1->keys().size() == num_of_conns);
   CPPUNIT_ASSERT(channel2->keys().size() == num_of_conns);
 
   for (auto auxid : channel1->keys()) {
-    std::cerr << ">>>>>>>>>>>>> client(" << (int)auxid.get_id()
+    LOG(INFO) << ">>>>>>>>>>>>> client(" << (int)auxid.get_id()
               << ") <<<<<<<<<<<<<<" << std::endl;
     if (not channel1->has_conn(auxid)) {
       continue;
@@ -128,14 +129,14 @@ void crofchantest::test_connections() {
     channel1->drop_conn(auxid);
   }
 
-  std::cerr << "num_of_ctl_established = " << num_of_ctl_established
-            << std::endl;
-  std::cerr << "num_of_dpt_established = " << num_of_dpt_established
-            << std::endl;
-  std::cerr << "num_of_conns = " << num_of_conns << std::endl;
-  std::cerr << "num_of_accepts = " << num_of_accepts << std::endl;
-  std::cerr << "channel1.size() = " << channel1->keys().size() << std::endl;
-  std::cerr << "channel2.size() = " << channel2->keys().size() << std::endl;
+  LOG(INFO) << "num_of_ctl_established = " << num_of_ctl_established
+            << std::endl
+            << "num_of_dpt_established = " << num_of_dpt_established
+            << std::endl
+            << "num_of_conns = " << num_of_conns << std::endl
+            << "num_of_accepts = " << num_of_accepts << std::endl
+            << "channel1.size() = " << channel1->keys().size() << std::endl
+            << "channel2.size() = " << channel2->keys().size() << std::endl;
   CPPUNIT_ASSERT(channel1->keys().size() == 0);
   CPPUNIT_ASSERT(channel2->keys().size() == 0);
 }
@@ -160,12 +161,12 @@ void crofchantest::test_congestion() {
       listening_port = rand.uint16();
     } while ((listening_port < 10000) || (listening_port > 49000));
     try {
-      std::cerr << "trying listening port=" << (int)listening_port << std::endl;
+      LOG(INFO) << "trying listening port=" << (int)listening_port << std::endl;
       baddr = rofl::csockaddr(rofl::caddress_in4("127.0.0.1"), listening_port);
       /* try to bind address first */
       rofsock->set_backlog(num_of_conns);
       rofsock->set_baddr(baddr).listen();
-      std::cerr << "binding to " << baddr.str() << std::endl;
+      LOG(INFO) << "binding to " << baddr.str() << std::endl;
       lookup_idle_port = false;
     } catch (rofl::eSysCall &e) {
       /* port in use, try another one */
@@ -183,7 +184,7 @@ void crofchantest::test_congestion() {
 
     num_of_dpt_established++;
 
-    std::cerr << "auxid(" << i << "): connecting to " << baddr.str()
+    LOG(INFO) << "auxid(" << i << "): connecting to " << baddr.str()
               << std::endl;
   }
 
@@ -192,32 +193,32 @@ void crofchantest::test_congestion() {
     ts.tv_sec = 2;
     ts.tv_nsec = 0;
     pselect(0, NULL, NULL, NULL, &ts, NULL);
-    // std::cerr << ".";
+    // LOG(INFO) << ".";
   }
   keep_running = false;
   sleep(2);
 
-  std::cerr << ">>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<" << std::endl;
-  std::cerr << ">>>          TERMINATING          <<<" << std::endl;
-  std::cerr << ">>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<" << std::endl;
+  LOG(INFO) << ">>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<" << std::endl
+            << ">>>          TERMINATING          <<<" << std::endl
+            << ">>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<" << std::endl
 
-  std::cerr << ">>>>>>>>>>>>> listen <<<<<<<<<<<<<<" << std::endl;
+            << ">>>>>>>>>>>>> listen <<<<<<<<<<<<<<" << std::endl
 
-  std::cerr << "num_of_ctl_established = " << num_of_ctl_established
-            << std::endl;
-  std::cerr << "num_of_dpt_established = " << num_of_dpt_established
-            << std::endl;
-  std::cerr << "num_of_conns = " << num_of_conns << std::endl;
-  std::cerr << "num_of_accepts = " << num_of_accepts << std::endl;
-  std::cerr << "channel1.size() = " << channel1->keys().size() << std::endl;
-  std::cerr << "channel2.size() = " << channel2->keys().size() << std::endl;
-  std::cerr << "num_of_pkts_sent = " << num_of_pkts_sent << std::endl;
-  std::cerr << "num_of_pkts_rcvd = " << num_of_pkts_rcvd << std::endl;
+            << "num_of_ctl_established = " << num_of_ctl_established
+            << std::endl
+            << "num_of_dpt_established = " << num_of_dpt_established
+            << std::endl
+            << "num_of_conns = " << num_of_conns << std::endl
+            << "num_of_accepts = " << num_of_accepts << std::endl
+            << "channel1.size() = " << channel1->keys().size() << std::endl
+            << "channel2.size() = " << channel2->keys().size() << std::endl
+            << "num_of_pkts_sent = " << num_of_pkts_sent << std::endl
+            << "num_of_pkts_rcvd = " << num_of_pkts_rcvd << std::endl;
   CPPUNIT_ASSERT(channel1->keys().size() == num_of_conns);
   CPPUNIT_ASSERT(channel2->keys().size() == num_of_conns);
 
   for (auto auxid : channel1->keys()) {
-    std::cerr << ">>>>>>>>>>>>> client(" << (int)auxid.get_id()
+    LOG(INFO) << ">>>>>>>>>>>>> client(" << (int)auxid.get_id()
               << ") <<<<<<<<<<<<<<" << std::endl;
     if (not channel1->has_conn(auxid)) {
       continue;
@@ -228,7 +229,7 @@ void crofchantest::test_congestion() {
     if (not channel2->has_conn(auxid)) {
       continue;
     }
-    std::cerr << "dropping channel2 auxid=" << auxid << std::endl;
+    LOG(INFO) << "dropping channel2 auxid=" << auxid << std::endl;
     channel2->drop_conn(auxid);
   }
 
@@ -236,20 +237,20 @@ void crofchantest::test_congestion() {
     if (not channel1->has_conn(auxid)) {
       continue;
     }
-    std::cerr << "dropping channel1 auxid=" << auxid << std::endl;
+    LOG(INFO) << "dropping channel1 auxid=" << auxid << std::endl;
     channel1->drop_conn(auxid);
   }
 
   sleep(2);
 
-  std::cerr << "num_of_ctl_established = " << num_of_ctl_established
-            << std::endl;
-  std::cerr << "num_of_dpt_established = " << num_of_dpt_established
-            << std::endl;
-  std::cerr << "num_of_conns = " << num_of_conns << std::endl;
-  std::cerr << "num_of_accepts = " << num_of_accepts << std::endl;
-  std::cerr << "channel1.size() = " << channel1->keys().size() << std::endl;
-  std::cerr << "channel2.size() = " << channel2->keys().size() << std::endl;
+  LOG(INFO) << "num_of_ctl_established = " << num_of_ctl_established
+            << std::endl
+            << "num_of_dpt_established = " << num_of_dpt_established
+            << std::endl
+            << "num_of_conns = " << num_of_conns << std::endl
+            << "num_of_accepts = " << num_of_accepts << std::endl
+            << "channel1.size() = " << channel1->keys().size() << std::endl
+            << "channel2.size() = " << channel2->keys().size() << std::endl;
   CPPUNIT_ASSERT(channel1->keys().size() == 0);
   CPPUNIT_ASSERT(channel2->keys().size() == 0);
 }
@@ -257,13 +258,13 @@ void crofchantest::test_congestion() {
 void crofchantest::handle_listen(rofl::crofsock &socket) {
   for (auto sd : socket.accept()) {
     num_of_accepts++;
-    std::cerr << "num_of_accepts = " << num_of_accepts << std::endl;
+    LOG(INFO) << "num_of_accepts = " << num_of_accepts << std::endl;
 
     rofl::crofconn *conn = new rofl::crofconn(this);
     {
       rofl::AcquireReadWriteLock lock(plock);
       pending_conns.insert(conn);
-      std::cerr << "crofchantest::handle_listen() pending_conns: "
+      LOG(INFO) << "crofchantest::handle_listen() pending_conns: "
                 << pending_conns.size() << std::endl;
     }
     conn->tcp_accept(sd, versionbitmap, rofl::crofconn::MODE_CONTROLLER);
@@ -275,44 +276,41 @@ void crofchantest::handle_established(rofl::crofconn &conn,
   {
     rofl::AcquireReadWriteLock lock(plock);
     pending_conns.erase(&conn);
-    std::cerr << "crofchantest::handle_established() pending_conns: "
+    LOG(INFO) << "crofchantest::handle_established() pending_conns: "
               << pending_conns.size() << std::endl;
   }
 
   channel2->add_conn(&conn);
 
-  std::cerr << ">>>>>>>>>>>>> server(" << (int)conn.get_auxid().get_id()
-            << ") <<<<<<<<<<<<<<" << std::endl;
-
-  std::cerr << ">>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<" << std::endl;
-  std::cerr << ">>> crofchantest::handle_established() -conn-" << std::endl;
-  std::cerr << ">>> conn.get_auxid() = " << (int)conn.get_auxid().get_id()
-            << std::endl;
-  std::cerr << ">>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<" << std::endl;
+  LOG(INFO) << ">>>>>>>>>>>>> server(" << (int)conn.get_auxid().get_id()
+            << ") <<<<<<<<<<<<<<" << std::endl
+            << ">>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<" << std::endl
+            << ">>> crofchantest::handle_established() -conn-" << std::endl
+            << ">>> conn.get_auxid() = " << (int)conn.get_auxid().get_id()
+            << std::endl
+            << ">>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<" << std::endl;
 
   CPPUNIT_ASSERT(conn.is_established());
 
   num_of_ctl_established++;
-  std::cerr << "num_of_ctl_established = " << num_of_ctl_established
+  LOG(INFO) << "num_of_ctl_established = " << num_of_ctl_established
             << std::endl;
 }
 
 void crofchantest::handle_established(rofl::crofchan &chan,
                                       rofl::crofconn &conn,
                                       uint8_t ofp_version) {
-  std::cerr << std::endl;
-  std::cerr << ">>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<" << std::endl;
-  std::cerr << ">>> crofchantest::handle_established() -chan-" << std::endl;
-  std::cerr << ">>> num_of_accepts = " << num_of_accepts << std::endl;
-  std::cerr << ">>> num_of_conns   = " << num_of_conns << std::endl;
-  std::cerr << ">>> channel1.size() = " << channel1->size() << std::endl;
-  std::cerr << ">>> channel2.size() = " << channel2->size() << std::endl;
-  std::cerr << ">>> conn.get_auxid() = " << (int)conn.get_auxid().get_id()
-            << std::endl;
-  std::cerr << ">>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<" << std::endl;
-  std::cerr << std::endl;
-
-  std::cerr << "crofchan::handle_established" << std::endl;
+  LOG(INFO) << ">>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<" << std::endl
+            << ">>> crofchantest::handle_established() -chan-" << std::endl
+            << ">>> num_of_accepts = " << num_of_accepts << std::endl
+            << ">>> num_of_conns   = " << num_of_conns << std::endl
+            << ">>> channel1.size() = " << channel1->size() << std::endl
+            << ">>> channel2.size() = " << channel2->size() << std::endl
+            << ">>> conn.get_auxid() = " << (int)conn.get_auxid().get_id()
+            << std::endl
+            << ">>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<" << std::endl
+            << std::endl
+            << "crofchan::handle_established" << std::endl;
 
   CPPUNIT_ASSERT(conn.is_established());
 
@@ -340,7 +338,7 @@ void crofchantest::handle_timeout(rofl::cthread &thread, uint32_t timer_id) {
       match.set_eth_type(0x0806);
       rofl::cmemory packet(1500);
 
-      std::cerr << "crofchantest::handle_timeout() starting to overload "
+      LOG(INFO) << "crofchantest::handle_timeout() starting to overload "
                    "control connection"
                 << std::endl;
 
@@ -356,43 +354,43 @@ void crofchantest::handle_timeout(rofl::cthread &thread, uint32_t timer_id) {
         switch (channel1->set_conn(rofl::cauxid(0)).send_message(msg)) {
         case rofl::crofsock::MSG_QUEUED: {
           num_of_pkts_sent++;
-          // std::cerr << "MSG-QUEUED" << std::endl;
+          // LOG(INFO) << "MSG-QUEUED" << std::endl;
           /* keep going */
         } break;
         case rofl::crofsock::MSG_QUEUED_CONGESTION: {
           num_of_pkts_sent++;
-          // std::cerr << "MSG-QUEUED-CONGESTION" << std::endl;
-          std::cerr << "<C> " << std::endl;
+          // LOG(INFO) << "MSG-QUEUED-CONGESTION" << std::endl;
+          LOG(INFO) << "<C> " << std::endl;
           /* stop queueing and reschedule this function */
           thread.add_timer(TIMER_ID_START_SENDING_PACKET_INS,
                            rofl::ctimespec().expire_in(1));
         }
           return;
         case rofl::crofsock::MSG_QUEUEING_FAILED_QUEUE_FULL: {
-          // std::cerr << "MSG-DROPPED-QUEUE-FULL" << std::endl;
-          std::cerr << "<Q> " << std::endl;
+          // LOG(INFO) << "MSG-DROPPED-QUEUE-FULL" << std::endl;
+          LOG(INFO) << "<Q> " << std::endl;
           /* stop queueing and reschedule this function */
           thread.add_timer(TIMER_ID_START_SENDING_PACKET_INS,
                            rofl::ctimespec().expire_in(1));
         }
           return;
         case rofl::crofsock::MSG_QUEUEING_FAILED_NOT_ESTABLISHED: {
-          // std::cerr << "MSG-DROPPED-NOT-ESTABLISHED" << std::endl;
-          std::cerr << "<N> " << std::endl;
-          // std::cerr << "ERROR: crofsock::send_message() dropped message due
+          // LOG(INFO) << "MSG-DROPPED-NOT-ESTABLISHED" << std::endl;
+          LOG(INFO) << "<N> " << std::endl;
+          // LOG(INFO) << "ERROR: crofsock::send_message() dropped message due
           // to connection now established" << std::endl;
           /* stop this test, something failed */
           keep_running = false;
         }
           return;
         case rofl::crofsock::MSG_QUEUEING_FAILED_SHUTDOWN_IN_PROGRESS: {
-          std::cerr << "<S> " << std::endl;
-          // std::cerr << "MSG-DROPPED-SHUTDOWN-IN-PROGRESS" << std::endl;
+          LOG(INFO) << "<S> " << std::endl;
+          // LOG(INFO) << "MSG-DROPPED-SHUTDOWN-IN-PROGRESS" << std::endl;
           /* stop this test, something failed */
           keep_running = false;
         } break;
         default: {
-          // std::cerr << "ERROR: received unhandled return value from
+          // LOG(INFO) << "ERROR: received unhandled return value from
           // crofsock::send_message()" << std::endl;
           /* stop this test, something failed */
           keep_running = false;
@@ -404,11 +402,11 @@ void crofchantest::handle_timeout(rofl::cthread &thread, uint32_t timer_id) {
       }
 
     } catch (rofl::eRofQueueFull &e) {
-      std::cerr << "exception caught: eRofQueueFull" << std::endl;
+      LOG(INFO) << "exception caught: eRofQueueFull" << std::endl;
       thread.add_timer(TIMER_ID_START_SENDING_PACKET_INS,
                        rofl::ctimespec().expire_in(4));
     } catch (rofl::eRofSockNotEstablished &e) {
-      std::cerr << "exception caught: eRofSockNotEstablished" << std::endl;
+      LOG(INFO) << "exception caught: eRofSockNotEstablished" << std::endl;
       thread.add_timer(TIMER_ID_START_SENDING_PACKET_INS,
                        rofl::ctimespec().expire_in(4));
     }
@@ -423,8 +421,8 @@ void crofchantest::handle_recv(rofl::crofchan &chan, rofl::crofconn &conn,
   switch (pmsg->get_type()) {
   case rofl::openflow13::OFPT_FEATURES_REQUEST: {
 
-    std::cerr << "crofchantest::handle_recv() message: " << std::endl << *pmsg;
-    std::cerr << "sending FEATURES-REPLY auxid: "
+    LOG(INFO) << "crofchantest::handle_recv() message: " << std::endl
+              << *pmsg << "sending FEATURES-REPLY auxid: "
               << (int)conn.get_auxid().get_id() << std::endl;
 
     rofl::openflow::cofmsg_features_reply *msg =
@@ -453,8 +451,8 @@ void crofchantest::handle_recv(rofl::crofchan &chan, rofl::crofconn &conn,
 
 void crofchantest::congestion_solved_indication(rofl::crofchan &chan,
                                                 rofl::crofconn &conn) {
-  std::cerr << "crofchan::congestion_solved_indication: ";
-  std::cerr << "num_of_pkts_sent=" << num_of_pkts_sent
+  LOG(INFO) << "crofchan::congestion_solved_indication: "
+            << "num_of_pkts_sent=" << num_of_pkts_sent
             << " num_of_pkts_rcvd=" << num_of_pkts_rcvd
             << " max_congestion_rounds=" << max_congestion_rounds << std::endl;
 
@@ -469,8 +467,8 @@ void crofchantest::congestion_solved_indication(rofl::crofchan &chan,
 void crofchantest::congestion_occurred_indication(rofl::crofchan &chan,
                                                   rofl::crofconn &conn) {
   congested = true;
-  std::cerr << "crofchan::congestion_occurred_indication: ";
-  std::cerr << "num_of_pkts_sent=" << num_of_pkts_sent
+  LOG(INFO) << "crofchan::congestion_occurred_indication: "
+            << "num_of_pkts_sent=" << num_of_pkts_sent
             << " num_of_pkts_rcvd=" << num_of_pkts_rcvd
             << " max_congestion_rounds=" << max_congestion_rounds << std::endl;
 }

--- a/test/rofl/common/crofchan/crofchantest.hpp
+++ b/test/rofl/common/crofchan/crofchantest.hpp
@@ -5,12 +5,12 @@
  *      Author: andi
  */
 
-#ifndef TEST_SRC_ROFL_COMMON_OPENFLOW_MESSAGES_COFMSGAGGRSTATS_TEST_HPP_
-#define TEST_SRC_ROFL_COMMON_OPENFLOW_MESSAGES_COFMSGAGGRSTATS_TEST_HPP_
+#pragma once
 
 #include <atomic>
 #include <cppunit/TestFixture.h>
 #include <cppunit/extensions/HelperMacros.h>
+#include <glog/logging.h>
 #include <set>
 
 #include "rofl/common/crofchan.h"
@@ -21,7 +21,7 @@ class crofchantest : public CppUnit::TestFixture,
                      public rofl::crofchan_env,
                      public rofl::crofconn_env,
                      public rofl::crofsock_env,
-                     public rofl::cthread_env {
+                     public rofl::cthread_timeout_event {
   CPPUNIT_TEST_SUITE(crofchantest);
   CPPUNIT_TEST(test_connections);
   CPPUNIT_TEST(test_congestion);
@@ -31,14 +31,10 @@ public:
   virtual ~crofchantest(){};
 
   crofchantest()
-      : num_of_pkts_sent(0), num_of_pkts_rcvd(0), thread(this),
-        max_congestion_rounds(16){};
+      : num_of_pkts_sent(0), num_of_pkts_rcvd(0), max_congestion_rounds(16){};
 
-public:
-  void setUp();
-  void tearDown();
-
-public:
+  void setUp() override;
+  void tearDown() override;
   void test_connections();
   void test_congestion();
 
@@ -53,12 +49,15 @@ private:
   std::atomic_uint num_of_accepts;
   unsigned int num_of_dpt_established;
   std::atomic_uint num_of_ctl_established;
+  bool send_packets;
 
   rofl::crandom rand;
   rofl::csockaddr baddr;
   rofl::crofsock *rofsock;
   rofl::crofchan *channel1;
   rofl::crofchan *channel2;
+  rofl::cthread tchan1;
+  rofl::cthread tchan2;
   rofl::crwlock rwlock;
 
   rofl::crwlock plock;
@@ -67,70 +66,60 @@ private:
   std::atomic_int num_of_pkts_sent;
   std::atomic_int num_of_pkts_rcvd;
   std::atomic_bool congested;
-
-  rofl::cthread thread;
   std::atomic_int max_congestion_rounds;
 
-private:
   enum crofchantest_timer_t {
     TIMER_ID_START_SENDING_PACKET_INS = 1,
   };
 
-  virtual void handle_wakeup(rofl::cthread &thread){};
+  void handle_timeout(void *userdata) override;
 
-  virtual void handle_timeout(rofl::cthread &thread, uint32_t timer_id);
-
-  virtual void handle_read_event(rofl::cthread &thread, int fd){};
-
-  virtual void handle_write_event(rofl::cthread &thread, int fd){};
-
-private:
-  virtual void handle_established(rofl::crofchan &chan, uint8_t ofp_version) {
-    std::cerr << "crofchan::handle_established" << std::endl;
+  void handle_established(rofl::crofchan &chan, uint8_t ofp_version) override {
+    LOG(INFO) << "crofchan::handle_established";
   };
 
-  virtual void handle_closed(rofl::crofchan &chan) {
-    std::cerr << "crofchan::handle_closed" << std::endl;
+  void handle_closed(rofl::crofchan &chan) override {
+    LOG(INFO) << "crofchan::handle_closed";
   };
 
-  virtual void handle_established(rofl::crofchan &chan, rofl::crofconn &conn,
-                                  uint8_t ofp_version);
+  void handle_established(rofl::crofchan &chan, rofl::crofconn &conn,
+                          uint8_t ofp_version) override;
 
-  virtual void handle_closed(rofl::crofchan &chan, rofl::crofconn &conn) {
-    std::cerr << "crofchan::handle_closed" << std::endl;
+  void handle_closed(rofl::crofchan &chan, rofl::crofconn &conn) override {
+    LOG(INFO) << "crofchan::handle_closed";
   };
 
-  virtual void handle_connect_refused(rofl::crofchan &chan,
-                                      rofl::crofconn &conn) {
-    std::cerr << "crofchan::handle_connect_refused" << std::endl;
+  void handle_connect_refused(rofl::crofchan &chan,
+                              rofl::crofconn &conn) override {
+    LOG(INFO) << "crofchan::handle_connect_refused";
   };
 
-  virtual void handle_connect_failed(rofl::crofchan &chan,
-                                     rofl::crofconn &conn) {
-    std::cerr << "crofchan::handle_connect_failed" << std::endl;
+  void handle_connect_failed(rofl::crofchan &chan,
+                             rofl::crofconn &conn) override {
+    LOG(INFO) << "crofchan::handle_connect_failed";
   };
 
-  virtual void handle_accept_failed(rofl::crofchan &chan,
-                                    rofl::crofconn &conn) {
-    std::cerr << "crofchan::handle_accept_failed" << std::endl;
+  void handle_accept_failed(rofl::crofchan &chan,
+                            rofl::crofconn &conn) override {
+    LOG(INFO) << "crofchan::handle_accept_failed";
   };
 
-  virtual void handle_negotiation_failed(rofl::crofchan &chan,
-                                         rofl::crofconn &conn) {
-    std::cerr << "crofchan::handle_negotiation_failed: pending_conns: "
-              << pending_conns.size() << std::endl;
-    std::cerr << ">>>>>>>>>>>>> auxid=" << (int)conn.get_auxid().get_id()
-              << " <<<<<<<<<<<<<<" << std::endl;
+  void handle_negotiation_failed(rofl::crofchan &chan,
+                                 rofl::crofconn &conn) override {
+    LOG(INFO) << "crofchan::handle_negotiation_failed: pending_conns: "
+              << pending_conns.size();
+    LOG(INFO) << ">>>>>>>>>>>>> auxid=" << (int)conn.get_auxid().get_id()
+              << " <<<<<<<<<<<<<<";
 
     rofl::AcquireReadWriteLock lock(plock);
     CPPUNIT_ASSERT(false);
   };
 
-  virtual void congestion_solved_indication(rofl::crofchan &chan,
-                                            rofl::crofconn &conn);
+  void congestion_solved_indication(rofl::crofchan &chan,
+                                    rofl::crofconn &conn) override;
 
-  virtual void handle_recv(rofl::crofchan &chan, rofl::crofconn &conn,
-                           rofl::openflow::cofmsg *msg);
+  void handle_recv(rofl::crofchan &chan, rofl::crofconn &conn,
+                   rofl::openflow::cofmsg *msg) override;
 
   virtual uint32_t get_async_xid(rofl::crofchan &chan) { return 0; };
 
@@ -140,123 +129,120 @@ private:
   };
 
   virtual void release_sync_xid(rofl::crofchan &chan, uint32_t xid) {
-    std::cerr << "crofchan::release_sync_xid" << std::endl;
+    LOG(INFO) << "crofchan::release_sync_xid";
   };
 
-  virtual void congestion_occurred_indication(rofl::crofchan &chan,
-                                              rofl::crofconn &conn);
+  void congestion_occurred_indication(rofl::crofchan &chan,
+                                      rofl::crofconn &conn) override;
 
-  virtual void handle_transaction_timeout(rofl::crofchan &chan,
-                                          rofl::crofconn &conn, uint32_t xid,
-                                          uint8_t type, uint16_t sub_type = 0) {
-    std::cerr << "crofchan::handle_transaction_timeout" << std::endl;
+  void handle_transaction_timeout(rofl::crofchan &chan, rofl::crofconn &conn,
+                                  uint32_t xid, uint8_t type,
+                                  uint16_t sub_type = 0) override {
+    LOG(INFO) << "crofchan::handle_transaction_timeout";
   };
 
-private:
-  virtual void handle_established(rofl::crofconn &conn, uint8_t ofp_version);
+  void handle_established(rofl::crofconn &conn, uint8_t ofp_version) override;
 
-  virtual void handle_connect_refused(rofl::crofconn &conn) {
-    std::cerr << "crofconn::handle_connect_refused" << std::endl;
+  void handle_connect_refused(rofl::crofconn &conn) override {
+    LOG(INFO) << "crofconn::handle_connect_refused";
   };
 
-  virtual void handle_connect_failed(rofl::crofconn &conn) {
-    std::cerr << "crofconn::handle_connect_failed" << std::endl;
+  void handle_connect_failed(rofl::crofconn &conn) override {
+    LOG(INFO) << "crofconn::handle_connect_failed";
   };
 
-  virtual void handle_accept_failed(rofl::crofconn &conn) {
-    std::cerr << "crofconn::handle_accept_failed" << std::endl;
+  void handle_accept_failed(rofl::crofconn &conn) override {
+    LOG(INFO) << "crofconn::handle_accept_failed";
   };
 
-  virtual void handle_negotiation_failed(rofl::crofconn &conn) {
-    std::cerr << "crofconn::handle_negotiation_failed" << std::endl;
-    std::cerr << ">>>>>>>>>>>>> auxid=" << (int)conn.get_auxid().get_id()
-              << " <<<<<<<<<<<<<<" << std::endl;
+  void handle_negotiation_failed(rofl::crofconn &conn) override {
+    LOG(INFO) << "crofconn::handle_negotiation_failed";
+    LOG(INFO) << ">>>>>>>>>>>>> auxid=" << (int)conn.get_auxid().get_id()
+              << " <<<<<<<<<<<<<<";
     CPPUNIT_ASSERT(false);
   };
 
-  virtual void handle_closed(rofl::crofconn &conn) {
-    std::cerr << "crofconn::handle_closed" << std::endl;
-    std::cerr << ">>>>>>>>>>>>> auxid=" << (int)conn.get_auxid().get_id()
-              << " <<<<<<<<<<<<<<" << std::endl;
+  void handle_closed(rofl::crofconn &conn) override {
+    LOG(INFO) << "crofconn::handle_closed";
+    LOG(INFO) << ">>>>>>>>>>>>> auxid=" << (int)conn.get_auxid().get_id()
+              << " <<<<<<<<<<<<<<";
     CPPUNIT_ASSERT(false);
   };
 
-  virtual void handle_recv(rofl::crofconn &conn, rofl::openflow::cofmsg *msg) {
-    std::cerr << "crofconn::handle_recv" << std::endl;
+  void handle_recv(rofl::crofconn &conn, rofl::openflow::cofmsg *msg) override {
+    LOG(INFO) << "crofconn::handle_recv";
   };
 
-  virtual void congestion_occurred_indication(rofl::crofconn &conn) {
-    std::cerr << "crofconn::congestion_occurred_indication" << std::endl;
+  void congestion_occurred_indication(rofl::crofconn &conn) override {
+    LOG(INFO) << "crofconn::congestion_occurred_indication";
   };
 
-  virtual void congestion_solved_indication(rofl::crofconn &conn) {
-    std::cerr << "crofconn::congestion_solved_indication" << std::endl;
+  void congestion_solved_indication(rofl::crofconn &conn) override {
+    LOG(INFO) << "crofconn::congestion_solved_indication";
   };
 
-  virtual void handle_transaction_timeout(rofl::crofconn &conn, uint32_t xid,
-                                          uint8_t type, uint16_t sub_type = 0) {
-    std::cerr << "crofconn::handle_transaction_timeout" << std::endl;
+  void handle_transaction_timeout(rofl::crofconn &conn, uint32_t xid,
+                                  uint8_t type,
+                                  uint16_t sub_type = 0) override {
+    LOG(INFO) << "crofconn::handle_transaction_timeout";
   };
 
-private:
-  virtual void handle_listen(rofl::crofsock &socket);
+  void handle_listen(rofl::crofsock &socket) override;
 
-  virtual void handle_tcp_connect_refused(rofl::crofsock &socket) {
-    std::cerr << "crofsock::handle_tcp_connect_refused" << std::endl;
+  void handle_tcp_connect_refused(rofl::crofsock &socket) override {
+    LOG(INFO) << "crofsock::handle_tcp_connect_refused";
   };
 
-  virtual void handle_tcp_connect_failed(rofl::crofsock &socket) {
-    std::cerr << "crofsock::handle_tcp_connect_failed" << std::endl;
+  void handle_tcp_connect_failed(rofl::crofsock &socket) override {
+    LOG(INFO) << "crofsock::handle_tcp_connect_failed";
   };
 
-  virtual void handle_tcp_connected(rofl::crofsock &socket) {
-    std::cerr << "crofsock::handle_tcp_connected" << std::endl;
+  void handle_tcp_connected(rofl::crofsock &socket) override {
+    LOG(INFO) << "crofsock::handle_tcp_connected";
   };
 
-  virtual void handle_tcp_accept_refused(rofl::crofsock &socket) {
-    std::cerr << "crofsock::handle_tcp_accept_refused" << std::endl;
+  void handle_tcp_accept_refused(rofl::crofsock &socket) override {
+    LOG(INFO) << "crofsock::handle_tcp_accept_refused";
   };
 
-  virtual void handle_tcp_accept_failed(rofl::crofsock &socket) {
-    std::cerr << "crofsock::handle_tcp_accept_failed" << std::endl;
+  void handle_tcp_accept_failed(rofl::crofsock &socket) override {
+    LOG(INFO) << "crofsock::handle_tcp_accept_failed";
   };
 
-  virtual void handle_tcp_accepted(rofl::crofsock &socket) {
-    std::cerr << "crofsock::handle_tcp_accepted" << std::endl;
+  void handle_tcp_accepted(rofl::crofsock &socket) override {
+    LOG(INFO) << "crofsock::handle_tcp_accepted";
   };
 
-  virtual void handle_tls_connect_failed(rofl::crofsock &socket) {
-    std::cerr << "crofsock::handle_tls_connect_failed" << std::endl;
+  void handle_tls_connect_failed(rofl::crofsock &socket) override {
+    LOG(INFO) << "crofsock::handle_tls_connect_failed";
   };
 
-  virtual void handle_tls_connected(rofl::crofsock &socket) {
-    std::cerr << "crofsock::handle_tls_connected" << std::endl;
+  void handle_tls_connected(rofl::crofsock &socket) override {
+    LOG(INFO) << "crofsock::handle_tls_connected";
   };
 
-  virtual void handle_tls_accept_failed(rofl::crofsock &socket) {
-    std::cerr << "crofsock::handle_tls_accept_failed" << std::endl;
+  void handle_tls_accept_failed(rofl::crofsock &socket) override {
+    LOG(INFO) << "crofsock::handle_tls_accept_failed";
   };
 
-  virtual void handle_tls_accepted(rofl::crofsock &socket) {
-    std::cerr << "crofsock::handle_tls_accepted" << std::endl;
+  void handle_tls_accepted(rofl::crofsock &socket) override {
+    LOG(INFO) << "crofsock::handle_tls_accepted";
   };
 
-  virtual void handle_closed(rofl::crofsock &socket) {
-    std::cerr << "crofsock::handle_closed" << std::endl;
+  void handle_closed(rofl::crofsock &socket) override {
+    LOG(INFO) << "crofsock::handle_closed";
   };
 
-  virtual void congestion_solved_indication(rofl::crofsock &socket) {
-    std::cerr << "congestion_solved_indication" << std::endl;
+  void congestion_solved_indication(rofl::crofsock &socket) override {
+    LOG(INFO) << "congestion_solved_indication";
   };
 
-  virtual void handle_recv(rofl::crofsock &socket,
-                           rofl::openflow::cofmsg *msg) {
-    std::cerr << "crofsock::handle_recv" << std::endl;
+  void handle_recv(rofl::crofsock &socket,
+                   rofl::openflow::cofmsg *msg) override {
+    LOG(INFO) << "crofsock::handle_recv";
   };
 
-  virtual void congestion_occurred_indication(rofl::crofsock &socket) {
-    std::cerr << "crofsock::congestion_occurred_indication" << std::endl;
+  void congestion_occurred_indication(rofl::crofsock &socket) override {
+    LOG(INFO) << "crofsock::congestion_occurred_indication";
   };
 };
-
-#endif /* TEST_SRC_ROFL_COMMON_OPENFLOW_MESSAGES_COFMSGAGGRSTATS_TEST_HPP_ */

--- a/test/rofl/common/crofchan/crofchantest.hpp
+++ b/test/rofl/common/crofchan/crofchantest.hpp
@@ -56,8 +56,8 @@ private:
   rofl::crofsock *rofsock;
   rofl::crofchan *channel1;
   rofl::crofchan *channel2;
-  rofl::cthread tchan1;
-  rofl::cthread tchan2;
+  rofl::cthread *tchan1;
+  rofl::cthread *tchan2;
   rofl::crwlock rwlock;
 
   rofl::crwlock plock;
@@ -167,11 +167,11 @@ private:
     LOG(INFO) << ">>>>>>>>>>>>> auxid=" << (int)conn.get_auxid().get_id()
               << " <<<<<<<<<<<<<<";
     CPPUNIT_ASSERT(false);
-  };
+  }
 
   void handle_recv(rofl::crofconn &conn, rofl::openflow::cofmsg *msg) override {
-    LOG(INFO) << "crofconn::handle_recv";
-  };
+    LOG(INFO) << "crofconn::handle_recv XXXX";
+  }
 
   void congestion_occurred_indication(rofl::crofconn &conn) override {
     LOG(INFO) << "crofconn::congestion_occurred_indication";

--- a/test/rofl/common/crofchan/unittest.cpp
+++ b/test/rofl/common/crofchan/unittest.cpp
@@ -8,8 +8,11 @@
 #include <cppunit/extensions/TestFactoryRegistry.h>
 #include <cppunit/ui/text/TestRunner.h>
 #include <stdlib.h>
+#include <glog/logging.h>
 
 int main(int argc, char **argv) {
+  google::InitGoogleLogging(argv[0]);
+
   CppUnit::TextUi::TestRunner runner;
   CppUnit::TestFactoryRegistry &registry =
       CppUnit::TestFactoryRegistry::getRegistry();

--- a/test/rofl/common/crofchan/unittest.cpp
+++ b/test/rofl/common/crofchan/unittest.cpp
@@ -7,8 +7,8 @@
 
 #include <cppunit/extensions/TestFactoryRegistry.h>
 #include <cppunit/ui/text/TestRunner.h>
-#include <stdlib.h>
 #include <glog/logging.h>
+#include <stdlib.h>
 
 int main(int argc, char **argv) {
   google::InitGoogleLogging(argv[0]);

--- a/test/rofl/common/crofconn/crofconntest.cpp
+++ b/test/rofl/common/crofconn/crofconntest.cpp
@@ -16,9 +16,15 @@ using namespace rofl::openflow;
 
 CPPUNIT_TEST_SUITE_REGISTRATION(crofconntest);
 
-void crofconntest::setUp() {}
+void crofconntest::setUp() {
+  tclient.start("client");
+  tserver.start("server");
+}
 
-void crofconntest::tearDown() {}
+void crofconntest::tearDown() {
+  tclient.stop();
+  tserver.stop();
+}
 
 void crofconntest::test() {
   try {
@@ -34,8 +40,8 @@ void crofconntest::test() {
     xid_client = 0;
     xid_server = 0;
 
-    slisten = new rofl::crofsock(this);
-    sclient = new rofl::crofconn(this);
+    slisten = new rofl::crofsock(&tserver, this);
+    sclient = new rofl::crofconn(&tclient, this);
 
     listening_port = 0;
 
@@ -86,6 +92,12 @@ void crofconntest::test() {
     std::cerr << "c:" << cli_pkts_rcvd << "(" << srv_pkts_sent << "), "
               << std::endl;
 
+    slisten->close();
+    sclient->close();
+    sserver->close();
+
+    sleep(2);
+
     delete slisten;
     delete sclient;
     delete sserver;
@@ -114,7 +126,7 @@ void crofconntest::handle_listen(rofl::crofsock &socket) {
       versionbitmap_ctl.add_ofp_version(rofl::openflow12::OFP_VERSION);
       versionbitmap_ctl.add_ofp_version(rofl::openflow13::OFP_VERSION);
 
-      sserver = new rofl::crofconn(this);
+      sserver = new rofl::crofconn(&tserver, this);
       sserver->tcp_accept(sd, versionbitmap_ctl,
                           rofl::crofconn::MODE_CONTROLLER);
 

--- a/test/rofl/common/crofconn/crofconntest.cpp
+++ b/test/rofl/common/crofconn/crofconntest.cpp
@@ -82,10 +82,6 @@ void crofconntest::test() {
     }
     std::cerr << std::endl;
 
-    slisten->close();
-    sclient->close();
-    sserver->close();
-
     std::cerr << "s:" << srv_pkts_rcvd << "(" << cli_pkts_sent << "), ";
     std::cerr << "c:" << cli_pkts_rcvd << "(" << srv_pkts_sent << "), "
               << std::endl;

--- a/test/rofl/common/crofconn/crofconntest.cpp
+++ b/test/rofl/common/crofconn/crofconntest.cpp
@@ -77,7 +77,7 @@ void crofconntest::test() {
       struct timespec ts;
       ts.tv_sec = 1;
       ts.tv_nsec = 0;
-      pselect(0, NULL, NULL, NULL, &ts, NULL);
+      pselect(0, nullptr, nullptr, nullptr, &ts, nullptr);
       std::cerr << "s:" << srv_pkts_rcvd << "(" << cli_pkts_sent << "), ";
       std::cerr << "c:" << cli_pkts_rcvd << "(" << srv_pkts_sent << "), "
                 << std::endl;

--- a/test/rofl/common/crofconn/crofconntest.hpp
+++ b/test/rofl/common/crofconn/crofconntest.hpp
@@ -102,24 +102,24 @@ private:
   rofl::crofsock *slisten;
   rofl::crofconn *sclient;
   rofl::crofconn *sserver;
-  uint32_t xid_server;
+  std::atomic_uint_fast32_t xid_server;
   uint32_t xid_client;
   uint16_t listening_port;
   rofl::crandom rand;
   rofl::csockaddr baddr;
 
   uint32_t xid;
-  uint64_t dpid;
-  uint8_t auxid;
-  uint32_t n_buffers;
-  uint8_t n_tables;
+  std::atomic_uint_fast64_t dpid;
+  std::atomic_uint_fast8_t auxid;
+  std::atomic_uint_fast32_t n_buffers;
+  std::atomic_uint_fast8_t n_tables;
   rofl::openflow::cofports ports;
 
-  int num_of_packets;
-  int srv_pkts_rcvd;
-  int srv_pkts_sent;
-  int cli_pkts_rcvd;
-  int cli_pkts_sent;
+  std::atomic_int num_of_packets;
+  std::atomic_int srv_pkts_rcvd;
+  std::atomic_int srv_pkts_sent;
+  std::atomic_int cli_pkts_rcvd;
+  std::atomic_int cli_pkts_sent;
 };
 
 #endif /* TEST_SRC_ROFL_COMMON_OPENFLOW_MESSAGES_COFMSGAGGRSTATS_TEST_HPP_ */

--- a/test/rofl/common/crofconn/crofconntest.hpp
+++ b/test/rofl/common/crofconn/crofconntest.hpp
@@ -14,6 +14,7 @@
 #include "rofl/common/cmemory.h"
 #include "rofl/common/crofconn.h"
 #include "rofl/common/crofsock.h"
+#include "rofl/common/cthread.hpp"
 
 class crofconntest : public CppUnit::TestFixture,
                      public rofl::crofconn_env,
@@ -102,6 +103,8 @@ private:
   rofl::crofsock *slisten;
   rofl::crofconn *sclient;
   rofl::crofconn *sserver;
+  rofl::cthread tclient;
+  rofl::cthread tserver;
   std::atomic_uint_fast32_t xid_server;
   uint32_t xid_client;
   uint16_t listening_port;

--- a/test/rofl/common/crofsock/Makefile.am
+++ b/test/rofl/common/crofsock/Makefile.am
@@ -12,5 +12,6 @@ crofsocktest_LDADD= $(top_builddir)/src/rofl/librofl_common.la -lcppunit
 
 #Tests
 
+AM_TESTS_ENVIRONMENT = GLOG_logtostderr=1
 check_PROGRAMS= crofsocktest
 TESTS = crofsocktest

--- a/test/rofl/common/crofsock/crofsocktest.cpp
+++ b/test/rofl/common/crofsock/crofsocktest.cpp
@@ -66,15 +66,9 @@ void crofsocktest::test() {
 
       CPPUNIT_ASSERT(timeout > 0);
 
-      slisten->close();
-      sclient->close();
-      sserver->close();
-
-      sleep(5);
-
-      delete slisten;
       delete sclient;
       delete sserver;
+      delete slisten;
     }
 
   } catch (rofl::eSysCall &e) {

--- a/test/rofl/common/crofsock/crofsocktest.cpp
+++ b/test/rofl/common/crofsock/crofsocktest.cpp
@@ -9,6 +9,7 @@
 
 #include <cppunit/extensions/TestFactoryRegistry.h>
 #include <cppunit/ui/text/TestRunner.h>
+#include <glog/logging.h>
 
 #include "crofsocktest.hpp"
 
@@ -39,13 +40,13 @@ void crofsocktest::test() {
           listening_port = rand.uint16();
         } while ((listening_port < 10000) || (listening_port > 49000));
         try {
-          std::cerr << "trying listening port=" << (int)listening_port
+          LOG(INFO) << "trying listening port=" << (int)listening_port
                     << std::endl;
           baddr =
               rofl::csockaddr(rofl::caddress_in4("127.0.0.1"), listening_port);
           /* try to bind address first */
           slisten->set_baddr(baddr).listen();
-          std::cerr << "binding to " << baddr.str() << std::endl;
+          LOG(INFO) << "binding to " << baddr.str() << std::endl;
           lookup_idle_port = false;
         } catch (rofl::eSysCall &e) {
           /* port in use, try another one */
@@ -77,10 +78,10 @@ void crofsocktest::test() {
     }
 
   } catch (rofl::eSysCall &e) {
-    std::cerr << "crofsocktest::test() exception, what: " << e.what()
+    LOG(INFO) << "crofsocktest::test() exception, what: " << e.what()
               << std::endl;
   } catch (std::runtime_error &e) {
-    std::cerr << "crofsocktest::test() exception, what: " << e.what()
+    LOG(INFO) << "crofsocktest::test() exception, what: " << e.what()
               << std::endl;
   }
 }
@@ -102,13 +103,13 @@ void crofsocktest::test_tls() {
         listening_port = rand.uint16();
       } while ((listening_port < 10000) || (listening_port > 49000));
       try {
-        std::cerr << "trying listening port=" << (int)listening_port
+        LOG(INFO) << "trying listening port=" << (int)listening_port
                   << std::endl;
         baddr =
             rofl::csockaddr(rofl::caddress_in4("127.0.0.1"), listening_port);
         /* try to bind address first */
         slisten->set_baddr(baddr).listen();
-        std::cerr << "binding to " << baddr.str() << std::endl;
+        LOG(INFO) << "binding to " << baddr.str() << std::endl;
         lookup_idle_port = false;
       } catch (rofl::eSysCall &e) {
         /* port in use, try another one */
@@ -135,20 +136,20 @@ void crofsocktest::test_tls() {
     delete sserver;
 
   } catch (rofl::eSysCall &e) {
-    std::cerr << "crofsocktest::test() exception, what: " << e.what()
+    LOG(INFO) << "crofsocktest::test() exception, what: " << e.what()
               << std::endl;
   } catch (std::runtime_error &e) {
-    std::cerr << "crofsocktest::test() exception, what: " << e.what()
+    LOG(INFO) << "crofsocktest::test() exception, what: " << e.what()
               << std::endl;
   }
 }
 
 void crofsocktest::handle_listen(rofl::crofsock &socket) {
-  std::cerr << "crofsocktest::handle_listen()" << std::endl;
+  LOG(INFO) << "crofsocktest::handle_listen()" << std::endl;
 
   for (auto sd : socket.accept()) {
 
-    std::cerr << "crofsocktest::handle_listen() sd=" << sd << std::endl;
+    LOG(INFO) << "crofsocktest::handle_listen() sd=" << sd << std::endl;
 
     sserver = new rofl::crofsock(this);
 
@@ -169,15 +170,15 @@ void crofsocktest::handle_listen(rofl::crofsock &socket) {
 }
 
 void crofsocktest::handle_tcp_connect_refused(rofl::crofsock &socket) {
-  std::cerr << "handle tcp connect refused" << std::endl;
+  LOG(INFO) << "handle tcp connect refused" << std::endl;
 }
 
 void crofsocktest::handle_tcp_connect_failed(rofl::crofsock &socket) {
-  std::cerr << "handle tcp connect failed" << std::endl;
+  LOG(INFO) << "handle tcp connect failed" << std::endl;
 }
 
 void crofsocktest::handle_tcp_connected(rofl::crofsock &socket) {
-  std::cerr << "handle connected" << std::endl;
+  LOG(INFO) << "handle connected" << std::endl;
 
   switch (test_mode) {
   case TEST_MODE_TCP: {
@@ -201,15 +202,15 @@ void crofsocktest::handle_tcp_connected(rofl::crofsock &socket) {
 }
 
 void crofsocktest::handle_tcp_accept_refused(rofl::crofsock &socket) {
-  std::cerr << "handle tcp accept refused" << std::endl;
+  LOG(INFO) << "handle tcp accept refused" << std::endl;
 }
 
 void crofsocktest::handle_tcp_accept_failed(rofl::crofsock &socket) {
-  std::cerr << "handle tcp accept failed" << std::endl;
+  LOG(INFO) << "handle tcp accept failed" << std::endl;
 }
 
 void crofsocktest::handle_tcp_accepted(rofl::crofsock &socket) {
-  std::cerr << "handle tcp accepted" << std::endl;
+  LOG(INFO) << "handle tcp accepted" << std::endl;
 
   switch (test_mode) {
   case TEST_MODE_TCP: {
@@ -233,21 +234,21 @@ void crofsocktest::handle_tcp_accepted(rofl::crofsock &socket) {
 }
 
 void crofsocktest::handle_closed(rofl::crofsock &socket) {
-  std::cerr << "handle closed" << std::endl;
+  LOG(INFO) << "handle closed" << std::endl;
 }
 
 void crofsocktest::congestion_solved_indication(rofl::crofsock &socket) {
-  std::cerr << "handle send" << std::endl;
+  LOG(INFO) << "handle send" << std::endl;
 }
 
 void crofsocktest::congestion_occurred_indication(rofl::crofsock &socket) {
-  std::cerr << "congestion indication" << std::endl;
+  LOG(INFO) << "congestion indication" << std::endl;
 }
 
 void crofsocktest::handle_recv(rofl::crofsock &socket,
                                rofl::openflow::cofmsg *msg) {
   if (&socket == sserver) {
-    std::cerr << "sserver => handle recv " << std::endl << *msg;
+    LOG(INFO) << "sserver => handle recv " << std::endl << *msg;
     delete msg;
 
     if (server_msg_counter < 10) {
@@ -261,12 +262,12 @@ void crofsocktest::handle_recv(rofl::crofsock &socket,
     }
 
     if ((server_msg_counter >= 10) && (client_msg_counter >= 10)) {
-      std::cerr << "[sserver] test done" << std::endl;
+      LOG(INFO) << "[sserver] test done" << std::endl;
       keep_running = false;
     }
 
   } else if (&socket == sclient) {
-    std::cerr << "sclient => handle recv " << std::endl << *msg;
+    LOG(INFO) << "sclient => handle recv " << std::endl << *msg;
     delete msg;
 
     if (client_msg_counter < 10) {
@@ -279,18 +280,18 @@ void crofsocktest::handle_recv(rofl::crofsock &socket,
     }
 
     if ((server_msg_counter >= 10) && (client_msg_counter >= 10)) {
-      std::cerr << "[sclient] test done" << std::endl;
+      LOG(INFO) << "[sclient] test done" << std::endl;
       keep_running = false;
     }
   }
 }
 
 void crofsocktest::handle_tls_connect_failed(rofl::crofsock &socket) {
-  std::cerr << "handle tls connect failed" << std::endl;
+  LOG(INFO) << "handle tls connect failed" << std::endl;
 }
 
 void crofsocktest::handle_tls_connected(rofl::crofsock &socket) {
-  std::cerr << "handle tls connected" << std::endl;
+  LOG(INFO) << "handle tls connected" << std::endl;
 
   rofl::openflow::cofmsg_hello *hello =
       new cofmsg_hello(rofl::openflow13::OFP_VERSION, 0xa1a2a3a4);
@@ -299,11 +300,11 @@ void crofsocktest::handle_tls_connected(rofl::crofsock &socket) {
 }
 
 void crofsocktest::handle_tls_accept_failed(rofl::crofsock &socket) {
-  std::cerr << "handle tls accept failed" << std::endl;
+  LOG(INFO) << "handle tls accept failed" << std::endl;
 }
 
 void crofsocktest::handle_tls_accepted(rofl::crofsock &socket) {
-  std::cerr << "handle tls accepted" << std::endl;
+  LOG(INFO) << "handle tls accepted" << std::endl;
 
   rofl::openflow::cofmsg_features_request *features =
       new cofmsg_features_request(rofl::openflow13::OFP_VERSION, 0xb1b2b3b4);

--- a/test/rofl/common/crofsock/crofsocktest.cpp
+++ b/test/rofl/common/crofsock/crofsocktest.cpp
@@ -67,7 +67,7 @@ void crofsocktest::test() {
         struct timespec ts;
         ts.tv_sec = 1;
         ts.tv_nsec = 0;
-        pselect(0, NULL, NULL, NULL, &ts, NULL);
+        pselect(0, nullptr, nullptr, nullptr, &ts, nullptr);
       }
 
       CPPUNIT_ASSERT(timeout > 0);
@@ -108,7 +108,7 @@ void crofsocktest::test_tls() {
       struct timespec ts;
       ts.tv_sec = 1;
       ts.tv_nsec = 0;
-      pselect(0, NULL, NULL, NULL, &ts, NULL);
+      pselect(0, nullptr, nullptr, nullptr, &ts, nullptr);
     }
 
     CPPUNIT_ASSERT(timeout > 0);

--- a/test/rofl/common/crofsock/crofsocktest.hpp
+++ b/test/rofl/common/crofsock/crofsocktest.hpp
@@ -71,7 +71,7 @@ private:
   int timeout;
   int msg_counter;
   std::atomic_int server_msg_counter;
-  int client_msg_counter;
+  std::atomic_int client_msg_counter;
   rofl::crandom rand;
   uint16_t listening_port;
   rofl::csockaddr baddr;

--- a/test/rofl/common/crofsock/crofsocktest.hpp
+++ b/test/rofl/common/crofsock/crofsocktest.hpp
@@ -78,6 +78,8 @@ private:
   rofl::crofsock *slisten;
   rofl::crofsock *sclient;
   rofl::crofsock *sserver;
+  rofl::cthread tclient;
+  rofl::cthread tserver;
 };
 
 #endif /* TEST_SRC_ROFL_COMMON_OPENFLOW_MESSAGES_COFMSGAGGRSTATS_TEST_HPP_ */

--- a/test/rofl/common/crofsock/crofsocktest.hpp
+++ b/test/rofl/common/crofsock/crofsocktest.hpp
@@ -5,8 +5,7 @@
  *      Author: andi
  */
 
-#ifndef TEST_SRC_ROFL_COMMON_OPENFLOW_MESSAGES_COFMSGAGGRSTATS_TEST_HPP_
-#define TEST_SRC_ROFL_COMMON_OPENFLOW_MESSAGES_COFMSGAGGRSTATS_TEST_HPP_
+#pragma once
 
 #include <cppunit/TestFixture.h>
 #include <cppunit/extensions/HelperMacros.h>
@@ -22,43 +21,44 @@ class crofsocktest : public CppUnit::TestFixture, public rofl::crofsock_env {
   CPPUNIT_TEST_SUITE_END();
 
 public:
-  void setUp();
-  void tearDown();
+  void setUp() override;
+  void tearDown() override;
 
 public:
   void test();
   void test_tls();
 
 private:
-  virtual void handle_listen(rofl::crofsock &socket);
+  void handle_listen(rofl::crofsock &socket) override;
 
-  virtual void handle_tcp_connect_refused(rofl::crofsock &socket);
+  void handle_tcp_connect_refused(rofl::crofsock &socket) override;
 
-  virtual void handle_tcp_connect_failed(rofl::crofsock &socket);
+  void handle_tcp_connect_failed(rofl::crofsock &socket) override;
 
-  virtual void handle_tcp_connected(rofl::crofsock &socket);
+  void handle_tcp_connected(rofl::crofsock &socket) override;
 
-  virtual void handle_tcp_accept_refused(rofl::crofsock &socket);
+  void handle_tcp_accept_refused(rofl::crofsock &socket) override;
 
-  virtual void handle_tcp_accept_failed(rofl::crofsock &socket);
+  void handle_tcp_accept_failed(rofl::crofsock &socket) override;
 
-  virtual void handle_tcp_accepted(rofl::crofsock &socket);
+  void handle_tcp_accepted(rofl::crofsock &socket) override;
 
-  virtual void handle_tls_connect_failed(rofl::crofsock &socket);
+  void handle_tls_connect_failed(rofl::crofsock &socket) override;
 
-  virtual void handle_tls_connected(rofl::crofsock &socket);
+  void handle_tls_connected(rofl::crofsock &socket) override;
 
-  virtual void handle_tls_accept_failed(rofl::crofsock &socket);
+  void handle_tls_accept_failed(rofl::crofsock &socket) override;
 
-  virtual void handle_tls_accepted(rofl::crofsock &socket);
+  void handle_tls_accepted(rofl::crofsock &socket) override;
 
-  virtual void handle_closed(rofl::crofsock &socket);
+  void handle_closed(rofl::crofsock &socket) override;
 
-  virtual void congestion_solved_indication(rofl::crofsock &socket);
+  void congestion_solved_indication(rofl::crofsock &socket) override;
 
-  virtual void handle_recv(rofl::crofsock &socket, rofl::openflow::cofmsg *msg);
+  void handle_recv(rofl::crofsock &socket,
+                   rofl::openflow::cofmsg *msg) override;
 
-  virtual void congestion_occurred_indication(rofl::crofsock &socket);
+  void congestion_occurred_indication(rofl::crofsock &socket) override;
 
 private:
   enum crofsock_test_mode_t {
@@ -78,8 +78,6 @@ private:
   rofl::crofsock *slisten;
   rofl::crofsock *sclient;
   rofl::crofsock *sserver;
-  rofl::cthread tclient;
-  rofl::cthread tserver;
+  rofl::cthread *tclient;
+  rofl::cthread *tserver;
 };
-
-#endif /* TEST_SRC_ROFL_COMMON_OPENFLOW_MESSAGES_COFMSGAGGRSTATS_TEST_HPP_ */

--- a/test/rofl/common/crofsock/unittest.cpp
+++ b/test/rofl/common/crofsock/unittest.cpp
@@ -8,8 +8,11 @@
 #include <cppunit/extensions/TestFactoryRegistry.h>
 #include <cppunit/ui/text/TestRunner.h>
 #include <stdlib.h>
+#include <glog/logging.h>
 
 int main(int argc, char **argv) {
+  google::InitGoogleLogging(argv[0]);
+
   CppUnit::TextUi::TestRunner runner;
   CppUnit::TestFactoryRegistry &registry =
       CppUnit::TestFactoryRegistry::getRegistry();

--- a/test/rofl/common/crofsock/unittest.cpp
+++ b/test/rofl/common/crofsock/unittest.cpp
@@ -7,8 +7,8 @@
 
 #include <cppunit/extensions/TestFactoryRegistry.h>
 #include <cppunit/ui/text/TestRunner.h>
-#include <stdlib.h>
 #include <glog/logging.h>
+#include <stdlib.h>
 
 int main(int argc, char **argv) {
   google::InitGoogleLogging(argv[0]);

--- a/test/rofl/common/cthread/cthread_test.cc
+++ b/test/rofl/common/cthread/cthread_test.cc
@@ -14,8 +14,8 @@ void cthread_test::tearDown() { delete object; }
 void cthread_test::test1() {
   unsigned int keep_running = 60;
 
-  object->thread.add_timer(0, rofl::ctimespec().expire_in(1));
-  object->thread.add_timer(1, rofl::ctimespec().expire_in(2));
+  object->thread.add_timer(object, 0, rofl::ctimespec().expire_in(1));
+  object->thread.add_timer(object, 1, rofl::ctimespec().expire_in(2));
 
   while ((--keep_running > 0) && (object->cnt < 10)) {
     CPPUNIT_ASSERT(not object->error);
@@ -26,15 +26,15 @@ void cthread_test::test1() {
   CPPUNIT_ASSERT(keep_running > 0);
 }
 
-void cthread_test::cobject::handle_timeout(rofl::cthread &thread,
-                                           uint32_t timer_id) {
+void cthread_test::cobject::handle_timeout(void *userdata) {
+  int timer_id = (long)userdata;
   switch (timer_id) {
   case 0: {
     cnt++;
     /* reschedule timer 0 */
-    thread.add_timer(0, rofl::ctimespec().expire_in(1));
+    thread.add_timer(this, 0, rofl::ctimespec().expire_in(1));
     /* reset timer 1, should never fire */
-    thread.add_timer(1, rofl::ctimespec().expire_in(2));
+    thread.add_timer(this, 1, rofl::ctimespec().expire_in(2));
   } break;
   case 1: {
     error = true;

--- a/test/rofl/common/cthread/cthread_test.h
+++ b/test/rofl/common/cthread/cthread_test.h
@@ -9,7 +9,7 @@ class cthread_test : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE_END();
 
 private:
-  class cobject : public rofl::cthread_env {
+  class cobject : public rofl::cthread_timeout_event {
   public:
     /**
      *
@@ -19,13 +19,10 @@ private:
     /**
      *
      */
-    cobject() : thread(this), cnt(0), error(false) { thread.start(); };
+    cobject() : cnt(0), error(false) { thread.start(); };
 
   protected:
-    virtual void handle_wakeup(rofl::cthread &thread){};
-    virtual void handle_timeout(rofl::cthread &thread, uint32_t timer_id);
-    virtual void handle_read_event(rofl::cthread &thread, int fd){};
-    virtual void handle_write_event(rofl::cthread &thread, int fd){};
+    void handle_timeout(void *userdata) override;
 
   public:
     rofl::cthread thread;


### PR DESCRIPTION
This PR enables the cthread class to be used by multiple instances as an event loop. All previous existing threads are collapsed into a single thread. Therefore callbacks can now be passed to cthread to cope e.g. with multiple wakeup events.