### PR TITLE
ensure all padding fields are set to value 0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,7 @@ v0.13.1
 [+] added experimental matches from OFDPA-2:
     VRF, OVID, ALLOW_VLAN_TRANSLATION, ACTSET_OUTPUT
 [B] fixed invalid length fields for experimental OXM matches
+[B] ensure all padding fields are set to value 0
 
 v0.13.0
 [+] thread pool

--- a/src/rofl/common/openflow/messages/cofmsg.cc
+++ b/src/rofl/common/openflow/messages/cofmsg.cc
@@ -19,6 +19,8 @@ void cofmsg::pack(uint8_t *buf, size_t buflen) {
   if (buflen < cofmsg::length())
     throw eInvalid("eInvalid", __FILE__, __FUNCTION__, __LINE__);
 
+  memset(buf, 0, buflen); // ensure padding fields to be set to 0
+
   struct rofl::openflow::ofp_header *hdr =
       (struct rofl::openflow::ofp_header *)buf;
 


### PR DESCRIPTION
Padding fields should contain value 0. rofl-common did not ensure this behaviour as defined by openflow 1.3.5 properly. This patch fixes this bug.