### PR TITLE
build: align make dist with specfile

### DIFF
--- a/tools/rpmbuild/SPECS/rofl-common.spec.in
+++ b/tools/rpmbuild/SPECS/rofl-common.spec.in
@@ -6,7 +6,7 @@ Summary:	Revised OpenFlow Library
 Group:		System Environment/Libraries
 License:	MPLv2.0
 URL:		https://github.com/bisdn/rofl-common
-Source0:	https://github.com/bisdn/rofl-common/archive/v%{version}.tar.gz
+Source0:	https://github.com/bisdn/rofl-common/archive/v%{version}.tar.gz#/rofl-common-%{version}.tar.gz
 
 BuildRequires:	gcc-c++
 BuildRequires:	openssl-devel


### PR DESCRIPTION
This PR aligns the source tarball from github with the one
built from calling make dist