### PR TITLE
cthread: fix compilation with OpenSSL 3.0+

### DIFF
--- a/src/rofl/common/cthread.cpp
+++ b/src/rofl/common/cthread.cpp
@@ -34,8 +34,10 @@ using namespace rofl;
 /*static*/ void cthread::openssl_initialize() {
   SSL_library_init();
   SSL_load_error_strings();
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
   ERR_load_ERR_strings();
   ERR_load_BIO_strings();
+#endif
   OpenSSL_add_all_algorithms();
   OpenSSL_add_all_ciphers();
   OpenSSL_add_all_digests();
@@ -57,7 +59,11 @@ using namespace rofl;
   OPENSSL_cleanup();
   ASN1_STRING_TABLE_cleanup();
 #endif
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+  EVP_default_properties_enable_fips(nullptr, 0);
+#else
   FIPS_mode_set(0);
+#endif
   ENGINE_cleanup();
   CONF_modules_unload(1);
   EVP_cleanup();


### PR DESCRIPTION
Fix the following errors/warning when compiling against OpenSSL 3.0 or
newer:

```
| ../../../../git/src/rofl/common/cthread.cpp: In static member function 'static void rofl::cthread::openssl_initialize()':
| ../../../../git/src/rofl/common/cthread.cpp:37:23: warning: 'int ERR_load_ERR_strings()' is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
|    37 |   ERR_load_ERR_strings();
|       |   ~~~~~~~~~~~~~~~~~~~~^~
| In file included from /tmp/kirkstone/work/cortexa9-vfp-poky-linux-gnueabi/rofl-common/0.13.4-r0/recipe-sysroot/usr/include/openssl/cryptoerr.h:17,
|                  from /tmp/kirkstone/work/cortexa9-vfp-poky-linux-gnueabi/rofl-common/0.13.4-r0/recipe-sysroot/usr/include/openssl/crypto.h:38,
|                  from /tmp/kirkstone/work/cortexa9-vfp-poky-linux-gnueabi/rofl-common/0.13.4-r0/recipe-sysroot/usr/include/openssl/bio.h:30,
|                  from ../../../../git/src/rofl/common/cthread.hpp:33,
|                  from ../../../../git/src/rofl/common/cthread.cpp:12:
| /tmp/kirkstone/work/cortexa9-vfp-poky-linux-gnueabi/rofl-common/0.13.4-r0/recipe-sysroot/usr/include/openssl/cryptoerr_legacy.h:57:27: note: declared here
|    57 | OSSL_DEPRECATEDIN_3_0 int ERR_load_ERR_strings(void);
|       |                           ^~~~~~~~~~~~~~~~~~~~
| ../../../../git/src/rofl/common/cthread.cpp:38:23: warning: 'int ERR_load_BIO_strings()' is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
|    38 |   ERR_load_BIO_strings();
|       |   ~~~~~~~~~~~~~~~~~~~~^~
| In file included from /tmp/kirkstone/work/cortexa9-vfp-poky-linux-gnueabi/rofl-common/0.13.4-r0/recipe-sysroot/usr/include/openssl/cryptoerr.h:17,
|                  from /tmp/kirkstone/work/cortexa9-vfp-poky-linux-gnueabi/rofl-common/0.13.4-r0/recipe-sysroot/usr/include/openssl/crypto.h:38,
|                  from /tmp/kirkstone/work/cortexa9-vfp-poky-linux-gnueabi/rofl-common/0.13.4-r0/recipe-sysroot/usr/include/openssl/bio.h:30,
|                  from ../../../../git/src/rofl/common/cthread.hpp:33,
|                  from ../../../../git/src/rofl/common/cthread.cpp:12:
| /tmp/kirkstone/work/cortexa9-vfp-poky-linux-gnueabi/rofl-common/0.13.4-r0/recipe-sysroot/usr/include/openssl/cryptoerr_legacy.h:31:27: note: declared here
|    31 | OSSL_DEPRECATEDIN_3_0 int ERR_load_BIO_strings(void);
|       |                           ^~~~~~~~~~~~~~~~~~~~
```

* ERR_load_*(), ERR_func_error_string(), ERR_get_error_line(), ERR_get_error_line_data(), ERR_get_state()
  OpenSSL now loads error strings automatically so these functions are not needed [1]

```
| ../../../../git/src/rofl/common/cthread.cpp: In static member function 'static void rofl::cthread::openssl_terminate()':
| ../../../../git/src/rofl/common/cthread.cpp:60:3: error: 'FIPS_mode_set' was not declared in this scope
|    60 |   FIPS_mode_set(0);
|       |   ^~~~~~~~~~~~~
```

The function calls 'FIPS_mode()' and 'FIPS_mode_set()' have been removed
from OpenSSL 3.0. [2]

EVP_default_properties_enable_fips() sets the 'fips=yes' to be a default
property if enable is non zero, otherwise it clears 'fips' from the
default property query for the given libctx (NULL signifies the default
library context). [3]

[1] https://github.com/openssl/openssl/blob/master/doc/man7/migration_guide.pod
[2] https://wiki.openssl.org/index.php/OpenSSL_3.0
[3] https://www.openssl.org/docs/man3.0/man3/EVP_default_properties_enable_fips.html

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>