### PR TITLE
fix build with newer libc versions

### DIFF
--- a/examples/ethswctld/cdaemon.cc
+++ b/examples/ethswctld/cdaemon.cc
@@ -6,6 +6,7 @@
  */
 
 #include "cdaemon.h"
+#include <cstdint>
 #include <stdexcept>
 
 using namespace rofl;

--- a/test/rofl/common/crofchan/crofchantest.cpp
+++ b/test/rofl/common/crofchan/crofchantest.cpp
@@ -391,7 +391,7 @@ void crofchantest::handle_timeout(rofl::cthread &thread, uint32_t timer_id) {
           return;
         }
 
-        pthread_yield();
+        sched_yield();
       }
 
     } catch (rofl::eRofQueueFull &e) {

--- a/test/rofl/common/crofsock/crofsocktest.cpp
+++ b/test/rofl/common/crofsock/crofsocktest.cpp
@@ -98,7 +98,7 @@ void crofsocktest::test() {
 
       sclient->set_raddr(baddr).tcp_connect(false);
 
-      pthread_yield();
+      sched_yield();
 
       while (keep_running && (--timeout > 0)) {
         struct timespec ts;


### PR DESCRIPTION
While trying to debug a race condition I stumbled upon the issue that rofl-common and its tests weren't compiling due to warnings (and warnings being treated as errors).

Fix this by fixing the warnings, i.e. add the missing include, and replace the deprecated calls of `pthread_yield()` with their replacement `sched_yield()` (which is called by pthread_yield() anyway).

Note that this does not allow all tests to succeed, the tests using SSL sockets will require additional changes on top.