### PR TITLE
crofsock: use sched_yield() instead of pthread_yield()

### DIFF
--- a/src/rofl/common/crofsock.cc
+++ b/src/rofl/common/crofsock.cc
@@ -110,11 +110,11 @@ void crofsock::close() {
         switch (err_code = SSL_get_error(ssl, rc)) {
         case SSL_ERROR_WANT_READ: {
           VLOG(6) << __FUNCTION__ << " TLS: shutdown WANT READ sd=" << sd;
-          pthread_yield();
+          sched_yield();
         } break;
         case SSL_ERROR_WANT_WRITE: {
           VLOG(6) << __FUNCTION__ << " TLS: shutdown WANT WRITE sd=" << sd;
-          pthread_yield();
+          sched_yield();
         } break;
         case SSL_ERROR_NONE: {
           VLOG(6) << __FUNCTION__


### PR DESCRIPTION
PR #128 noticed a deprecation for pthread_yield in crofsocktest and crofchantest, but did not address the same function call in crofsock. This PR complements that behavior.