### PR TITLE
configure.ac: work around broken libglog.pc in glog 0.7 and newer

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -57,6 +57,11 @@ PKG_CHECK_MODULES([GLOG], libglog >= 0.3.3,
   [ CPPFLAGS="$CPPFLAGS $GLOG_CFLAGS"
         LIBS="$LIBS $GLOG_LIBS $GFLAGS_LIBS" ],
   [ AC_MSG_ERROR([minimum version of glog is 0.3.3]) ])
+# glog 0.7's libglog.pc is broken and does not set the correct cflags, so set
+# them ourself as needed
+PKG_CHECK_MODULES([GLOG], libglog >= 0.7.0,
+  [ CPPFLAGS="$CPPFLAGS -DGFLAGS_IS_A_DLL=0 -DGLOG_USE_GFLAGS -DGLOG_USE_GLOG_EXPORT" ],
+  [ ] ])
 
 AC_SEARCH_LIBS([pthread_rwlock_wrlock], [pthread], [], [AC_MSG_ERROR([lib pthread not found])])
 


### PR DESCRIPTION
glog since 0.7 requires multiple flags to be set, but only the CMake files do set them, the undocumented and untested[1] libglog.pc does not define them.

So set them ourselves when building against a 0.7 libglog.

Also, glog now uses C++14 as the standard, so update that as well.

[1] https://github.com/google/glog/releases/tag/v0.7.0