### PR TITLE
configure: update C++ standard to C++14

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,7 +24,7 @@ AC_ENABLE_STATIC
 
 # default flags
 CFLAGS="-std=gnu89 -Werror -Wall $CFLAGS"
-CXXFLAGS="-std=c++11 -Werror -Wall $CXXFLAGS -Wno-error=array-bounds -Wno-error=maybe-uninitialized"
+CXXFLAGS="-std=c++14 -Werror -Wall $CXXFLAGS -Wno-error=array-bounds -Wno-error=maybe-uninitialized"
 AC_DEFINE([__STDC_FORMAT_MACROS], [], [Description])
 
 


### PR DESCRIPTION
Newer glog libraries use C++14 features, so bump the C++ version to stay compatible.

Avoids build errors like:

```
  CXX      crofbase.lo
In file included from crofbase.h:16,
                 from crofbase.cc:13:
/usr/include/glog/logging.h: In constructor 'google::LogMessage::LogStream::LogStream(google::LogMessage::LogStream&&)':
/usr/include/glog/logging.h:1262:21: error: 'exchange' is not a member of 'std'
 1262 |           ctr_(std::exchange(other.ctr_, 0)),
      |                     ^~~~~~~~
/usr/include/glog/logging.h:1262:21: note: 'std::exchange' is only available from C++14 onwards
```