### PR TITLE
avoid echo request lifechecks with pending barrier requests

### DIFF
--- a/src/rofl/common/crofconn.cc
+++ b/src/rofl/common/crofconn.cc
@@ -672,10 +672,22 @@ void crofconn::features_request_expired() {
 }
 
 void crofconn::send_echo_request() {
+
   try {
     if (rofsock.is_congested()) {
       VLOG(5) << __FUNCTION__
               << " need life check while socket is congested, skipping check: "
+              << " laddr=" << rofsock.get_laddr().str()
+              << " raddr=" << rofsock.get_raddr().str();
+      cthread::thread(thread_num)
+          .add_timer(this, TIMER_ID_NEED_LIFE_CHECK,
+                     ctimespec().expire_in(timeout_lifecheck));
+      return;
+    }
+
+    if (has_pending_barrier_request()) {
+      VLOG(5) << __FUNCTION__
+              << " need life check while barrier request pending, skipping check: "
               << " laddr=" << rofsock.get_laddr().str()
               << " raddr=" << rofsock.get_raddr().str();
       cthread::thread(thread_num)

--- a/src/rofl/common/crofconn.h
+++ b/src/rofl/common/crofconn.h
@@ -898,6 +898,16 @@ private:
         return (ta.get_xid() == xid);
       };
     };
+
+    class ctransaction_find_by_type {
+      uint8_t type;
+
+    public:
+      ctransaction_find_by_type(uint8_t type) : type(type){};
+      bool operator()(const ctransaction &ta) const {
+        return (ta.get_type() == type);
+      };
+    };
   };
 
   /**
@@ -952,6 +962,37 @@ private:
     std::set<ctransaction>::iterator it;
     if ((it = find_if(pending_requests.begin(), pending_requests.end(),
                       ctransaction::ctransaction_find_by_xid(xid))) !=
+        pending_requests.end()) {
+      return true;
+    }
+    return false;
+  };
+
+  /**
+   *
+   */
+  bool has_pending_barrier_request() const {
+    uint8_t type;
+    switch (ofp_version) {
+    default:
+    case rofl::openflow10::OFP_VERSION:
+        type = rofl::openflow10::OFPT_BARRIER_REQUEST;
+        break;
+    case rofl::openflow12::OFP_VERSION:
+        type = rofl::openflow12::OFPT_BARRIER_REQUEST;
+        break;
+    case rofl::openflow13::OFP_VERSION:
+        type = rofl::openflow13::OFPT_BARRIER_REQUEST;
+        break;
+    case rofl::openflow14::OFP_VERSION:
+        type = rofl::openflow14::OFPT_BARRIER_REQUEST;
+        break;
+    }
+
+    AcquireReadLock rlock(pending_requests_rwlock);
+    std::set<ctransaction>::iterator it;
+    if ((it = find_if(pending_requests.begin(), pending_requests.end(),
+                      ctransaction::ctransaction_find_by_type(type))) !=
         pending_requests.end()) {
       return true;
     }

--- a/src/rofl/common/crofdpt.h
+++ b/src/rofl/common/crofdpt.h
@@ -1433,7 +1433,7 @@ public:
    */
   rofl::crofsock::msg_result_t
   send_barrier_request(const rofl::cauxid &auxid,
-                       int timeout_in_secs = DEFAULT_REQUEST_TIMEOUT,
+                       int timeout_in_secs = DEFAULT_BARRIER_REQUEST_TIMEOUT,
                        uint32_t *xid = nullptr);
 
   /**
@@ -1854,6 +1854,9 @@ private:
 
   // default request timeout
   static const time_t DEFAULT_REQUEST_TIMEOUT = 0; // seconds (0 : no timeout)
+
+  // default barrier request timeout
+  static const time_t DEFAULT_BARRIER_REQUEST_TIMEOUT = 3600; // one hour
 
   // datapath identifier
   rofl::cdpid dpid;


### PR DESCRIPTION
The OpenFlow standard says that message processing stops while handling a barrier request:

> When the switch receives a `OFPT_BARRIER_REQUEST` message on a connection, the switch must finish processing all previously-received messages on that connection, including sending corresponding reply or error messages, before executing the barrier request or any messages on the connection received after the barrier request.

This means it also cannot answer any echo requests we may send to check the aliveness of the connection, but we currently send them anyway.

So inhibit sending echo requests by checking the pending messages for any barrier requests before sending them out.

This requires barrier requests to have a timeout > 0, so switch the default timeout for them to one hour.

Not that the default value change means that all users need to recompile against the new headers, else they continue using the old default one.